### PR TITLE
Do not require utils generated by Lem in ocamlbuild targets

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-USE_OCAMLBUILD ?= true
+USE_OCAMLBUILD ?= false
 
 ifeq "$(USE_OCAMLBUILD)" "false"
 	include no_ocamlbuild.mk

--- a/src/ocamlbuild.mk
+++ b/src/ocamlbuild.mk
@@ -6,5 +6,5 @@ include lem.mk
 clean: lem-clean
 	ocamlbuild -clean
 
-%.byte %.native: lem_ocaml_sentinel $(ALL_UTIL_ML)
+%.byte %.native: lem_ocaml_sentinel $(ALL_UTIL_ML_WO_LEM)
 	ocamlbuild -cflag -g -pkg 'unix str lem' $(INCLUDEFLAGS) "$@"


### PR DESCRIPTION
This fixes the `ocamlbuild` build if you don't have ML files generated from Lem yet (ie. after a fresh `git clone` or after `make clean`).

Fixes #5