### PR TITLE
Memory_image_orderings: list symbols outside loop

### DIFF
--- a/src/abis/abis.lem
+++ b/src/abis/abis.lem
@@ -61,7 +61,7 @@ let is_valid_abi_aarch64_relocation_operator op =
     | Indirect -> true
     | _ -> false
   end
-  
+
 val is_valid_abi_aarch64_relocation_operator2 : relocation_operator2 -> bool
 let is_valid_abi_aarch64_relocation_operator2 op =
   match op with
@@ -74,7 +74,7 @@ let is_valid_abi_amd64_relocation_operator op =
     | Indirect -> true
     | _ -> false (* XXX: not sure about this? *)
   end
-  
+
 val is_valid_abi_amd64_relocation_operator2 : relocation_operator2 -> bool
 let is_valid_abi_amd64_relocation_operator2 op =
   match op with
@@ -96,7 +96,7 @@ type any_abi_feature = Amd64AbiFeature of amd64_abi_feature any_abi_feature
                      | Aarch64LeAbiFeature of aarch64_le_abi_feature
 
 val anyAbiFeatureCompare : any_abi_feature -> any_abi_feature -> Basic_classes.ordering
-let anyAbiFeatureCompare f1 f2 = 
+let anyAbiFeatureCompare f1 f2 =
     match (f1, f2) with
         (Amd64AbiFeature(af1), Amd64AbiFeature(af2)) -> compare af1 af2
        |(Amd64AbiFeature(_), _) -> LT
@@ -105,7 +105,7 @@ let anyAbiFeatureCompare f1 f2 =
     end
 
 val anyAbiFeatureTagEquiv : any_abi_feature -> any_abi_feature -> bool
-let anyAbiFeatureTagEquiv f1 f2 = 
+let anyAbiFeatureTagEquiv f1 f2 =
     match (f1, f2) with
         (Amd64AbiFeature(af1), Amd64AbiFeature(af2)) -> abiFeatureTagEquiv af1 af2
        |(Amd64AbiFeature(_), _) -> false
@@ -126,8 +126,8 @@ instance (AbiFeatureTagEquiv any_abi_feature)
 end
 
 let make_elf64_header data osabi abiv ma t entry shoff phoff phnum shnum shstrndx =
-      <| elf64_ident    = [elf_mn_mag0; elf_mn_mag1; elf_mn_mag2; elf_mn_mag3; 
-                           unsigned_char_of_natural elf_class_64; 
+      <| elf64_ident    = [elf_mn_mag0; elf_mn_mag1; elf_mn_mag2; elf_mn_mag3;
+                           unsigned_char_of_natural elf_class_64;
                            unsigned_char_of_natural data;
                            unsigned_char_of_natural elf_ev_current;
                            unsigned_char_of_natural osabi;
@@ -153,14 +153,14 @@ let make_elf64_header data osabi abiv ma t entry shoff phoff phnum shnum shstrnd
        ; elf64_shnum    = elf64_half_of_natural shnum
        ; elf64_shstrndx = elf64_half_of_natural shstrndx
        |>
-       
+
 val phdr_flags_from_section_flags : natural -> string -> natural
 let phdr_flags_from_section_flags section_flags sec_name =
-    let flags = natural_lor elf_pf_r (natural_lor 
+    let flags = natural_lor elf_pf_r (natural_lor
         (if flag_is_set shf_write section_flags then elf_pf_w else 0)
         (if flag_is_set shf_execinstr section_flags then elf_pf_x else 0))
     in
-    (*let _ = errln ("Phdr flags of section " ^ sec_name ^ "(ELF section flags 0x " ^ 
+    (*let _ = errln ("Phdr flags of section " ^ sec_name ^ "(ELF section flags 0x " ^
         (hex_string_of_natural section_flags) ^ ") are 0x" ^ (hex_string_of_natural flags))
     in*)
     flags
@@ -171,10 +171,10 @@ let phdr_is_writable flags =
 
 type can_combine_flags_fn = set natural -> maybe natural
 
-(* FIXME: lift this to a personality function of the GNU linker? 
+(* FIXME: lift this to a personality function of the GNU linker?
  * Not sure really... need to try some other linkers. *)
 val load_can_combine_flags : can_combine_flags_fn
-let load_can_combine_flags flagsets = 
+let load_can_combine_flags flagsets =
     (* The GNU linker happily adds a .rodata section to a RX segment,
      * but not to a RW segment. So the only clear rule is: if any is writable,
      * all must be writable. *)
@@ -188,7 +188,7 @@ let load_can_combine_flags flagsets =
         else Nothing
     else
         Just union_flags
-        
+
 val tls_can_combine_flags : can_combine_flags_fn
 let tls_can_combine_flags flagsets = Just (List.foldl natural_lor 0 (Set_extra.toList flagsets))
 
@@ -203,19 +203,19 @@ let maybe_extend_phdr phdr isec can_combine_flags =
     else let new_p_flags = match maybe_extended_flags with Just flags -> flags | _ -> failwith "impossible" end
     in
     (* The new filesz is the file end offset of this section,
-     * minus the existing file start offset of the phdr. 
+     * minus the existing file start offset of the phdr.
      * Check that the new section begins after the old offset+filesz. *)
     if isec.elf64_section_offset < (natural_of_elf64_off phdr.elf64_p_offset) + (natural_of_elf64_xword phdr.elf64_p_filesz)
     then (*let _ = errln "offset went backwards" in*) Nothing
-    else 
+    else
     let new_p_filesz = natural_of_elf64_xword phdr.elf64_p_filesz + (if isec.elf64_section_type = sht_progbits then isec.elf64_section_size else 0)
-    in 
+    in
     (* The new memsz is the virtual address end address of this section,
-     * minus the existing start vaddr of the phdr. 
+     * minus the existing start vaddr of the phdr.
      * Check that the new section begins after the old vaddr+memsz. *)
     if isec.elf64_section_addr < (natural_of_elf64_addr phdr.elf64_p_vaddr) + (natural_of_elf64_xword phdr.elf64_p_memsz)
     then (*let _ = errln "vaddr went backwards" in*) Nothing
-    else 
+    else
     let new_p_memsz = natural_of_elf64_xword phdr.elf64_p_memsz + isec.elf64_section_size
     in
     let (one_if_zero : natural -> natural) = fun n -> if n = 0 then 1 else n
@@ -253,7 +253,7 @@ let make_new_phdr isec t maxpagesize commonpagesize =
    |>
 
 val make_load_phdrs : forall 'abifeature. natural -> natural -> annotated_memory_image 'abifeature -> list elf64_interpreted_section -> list elf64_program_header_table_entry
-let make_load_phdrs maxpagesize commonpagesize img section_pairs_bare_sorted_by_address = 
+let make_load_phdrs maxpagesize commonpagesize img section_pairs_bare_sorted_by_address =
     (* accumulate sections into the phdr *)
     let rev_list = List.foldl (fun accum_phdr_list -> (fun isec -> (
         (* Do we have a current phdr? *)
@@ -262,10 +262,10 @@ let make_load_phdrs maxpagesize commonpagesize img section_pairs_bare_sorted_by_
                 (*let _ = errln ("Starting the first LOAD phdr for section " ^ isec.elf64_section_name_as_string)
                 in*)
                 [make_new_phdr isec elf_pt_load maxpagesize commonpagesize]
-            | current_phdr :: more -> 
+            | current_phdr :: more ->
                 (* can we extend it with the current section? *)
                 match maybe_extend_phdr current_phdr isec load_can_combine_flags with
-                    Nothing -> 
+                    Nothing ->
                         (*let _ = errln ("Starting new LOAD phdr for section " ^ isec.elf64_section_name_as_string)
                         in*)
                         (make_new_phdr isec elf_pt_load maxpagesize commonpagesize) :: current_phdr :: more
@@ -280,7 +280,7 @@ let make_load_phdrs maxpagesize commonpagesize img section_pairs_bare_sorted_by_
     List.reverse rev_list
 
 val tls_extend: forall 'abifeature. abi 'abifeature -> abi 'abifeature
-let tls_extend a = 
+let tls_extend a =
    <| is_valid_elf_header = a.is_valid_elf_header
     ; make_elf_header     = a.make_elf_header
     ; reloc               = a.reloc
@@ -296,9 +296,9 @@ let tls_extend a =
             [] ->
                 (*let _ = errln "Making a new TLS program header" in*)
                 [make_new_phdr isec elf_pt_tls maxpagesize commonpagesize]
-            | current_phdr :: more -> 
+            | current_phdr :: more ->
                 match maybe_extend_phdr current_phdr isec tls_can_combine_flags with
-                    Nothing -> 
+                    Nothing ->
                         (make_new_phdr isec elf_pt_tls maxpagesize commonpagesize) :: current_phdr :: more
                     | Just phdr -> phdr :: more
                 end
@@ -320,18 +320,18 @@ let tls_extend a =
 (* We use these snappily-named functions in relocation calculations. *)
 
 val make_default_phdrs : forall 'abifeature. natural -> natural -> natural (* file type *) -> annotated_memory_image 'abifeature -> list elf64_interpreted_section -> list elf64_program_header_table_entry
-let make_default_phdrs maxpagesize commonpagesize t img section_pairs_bare_sorted_by_address = 
+let make_default_phdrs maxpagesize commonpagesize t img section_pairs_bare_sorted_by_address =
     (* FIXME: do the shared object and dyn. exec. stuff too *)
     make_load_phdrs maxpagesize commonpagesize img section_pairs_bare_sorted_by_address
 
 val find_start_symbol_address : forall 'abifeature. Ord 'abifeature, AbiFeatureTagEquiv 'abifeature => annotated_memory_image 'abifeature -> maybe natural
-let find_start_symbol_address img = 
+let find_start_symbol_address img =
     (* Do we have a symbol called "_start"? *)
     let all_defs = Memory_image_orderings.defined_symbols_and_ranges img
     in
-    let get_entry_point = (fun (maybe_range, symbol_def) -> 
+    let get_entry_point = (fun (maybe_range, symbol_def) ->
         if symbol_def.def_symname = "_start"
-        then Just (maybe_range, symbol_def) 
+        then Just (maybe_range, symbol_def)
         else Nothing
     )
     in
@@ -340,10 +340,10 @@ let find_start_symbol_address img =
     match all_entry_points with
         [(maybe_range, symbol_def)] ->
             match maybe_range with
-                Just (el_name, (el_off, len)) -> 
+                Just (el_name, (el_off, len)) ->
                     match Map.lookup el_name img.elements with
                         Nothing -> failwith ("_start symbol defined in nonexistent element `" ^ el_name ^ "'")
-                        | Just el_rec -> 
+                        | Just el_rec ->
                             match el_rec.startpos with
                                 Nothing -> (*let _ = Missing_pervasives.errln "warning: saw `_start' in element with no assigned address" in *)Nothing
                                 | Just x -> (* success! *) Just (x + el_off)
@@ -364,7 +364,7 @@ let pad_0x90 n = replicate n (byte_of_natural (9 * 16))
 
 (* null_abi captures ABI details common to all ELF-based, System V-based systems.
  * HACK: for now, specialise to 64-bit ABIs. *)
-val null_abi : abi any_abi_feature 
+val null_abi : abi any_abi_feature
 let (null_abi : abi any_abi_feature) = <|
       is_valid_elf_header = is_valid_elf64_header
     ; make_elf_header = make_elf64_header elf_data_2lsb elf_osabi_none 0 elf_ma_none
@@ -388,25 +388,25 @@ let (null_abi : abi any_abi_feature) = <|
 val got_entry_ordering : (string * maybe symbol_definition) -> (string * maybe symbol_definition) -> Basic_classes.ordering
 let got_entry_ordering (s1, md1) (s2, md2) = compare s1 s2 (* FIXME *)
 
-let is_ifunc_def = fun maybe_def -> 
+let is_ifunc_def = fun maybe_def ->
 match maybe_def with
  Nothing -> false
  | Just d -> get_elf64_symbol_type d.def_syment = stt_gnu_ifunc
 end
 
-let amd64_reloc_needs_got_slot =  fun symref -> fun rr -> fun maybe_def -> 
+let amd64_reloc_needs_got_slot =  fun symref -> fun rr -> fun maybe_def ->
     if (get_elf64_relocation_a_type rr.ref_relent IN {
         r_x86_64_got32; r_x86_64_gotpcrel; r_x86_64_gottpoff; r_x86_64_gotoff64; r_x86_64_gotpc32 (* ; r_x86_64_gotpc32_tlsdesc *)
-    }) then 
+    }) then
        true
     else if is_ifunc_def maybe_def
          then
-         (* This reference is bound to a STT_GNU_IFUNC definition. 
+         (* This reference is bound to a STT_GNU_IFUNC definition.
           * What now needs to happen is as follows.
           * - we ensure that a GOT entry is generated for this symbol (we do this here);
           * - we ensure that a PLT entry (specifically .iplt) is generated for the symbol (Below);
           * - on making the GOT, we also generate a .rela.plt relocation record covering the GOT slot;
-          * - when applying the relocation, of whatever kind, the address of the PLT slot 
+          * - when applying the relocation, of whatever kind, the address of the PLT slot
           *      is the address input to the calculation
           * - the code marked by the STT_GNU_IFUNC symbol definition is not the function
           *      to call; it's the function that calculates the address of the function to call!
@@ -425,17 +425,17 @@ let amd64_reloc_needs_plt_slot (symref : symbol_reference_and_reloc_site) rr may
                              * or undefined will need a slot. See amd64_get_reloc_symaddr. *)
     }) then
        not (ref_is_statically_linked rr)
-    else if is_ifunc_def maybe_def 
+    else if is_ifunc_def maybe_def
          then
          true
     else
         (* not a PLT ref *)
         false
 
-let amd64_find_got_label_and_element img = 
+let amd64_find_got_label_and_element img =
     match Map.lookup ".got" img.elements with
         Nothing -> (* got no GOT? okay... *) Nothing
-        | Just got_el -> 
+        | Just got_el ->
             (* Find the GOT tag. *)
             let tags_and_ranges = Multimap.lookupBy Memory_image_orderings.tagEquiv (AbiFeature(Amd64AbiFeature(Abi_amd64.GOT([])))) img.by_tag
             in
@@ -446,10 +446,10 @@ let amd64_find_got_label_and_element img =
             end
     end
 
-let amd64_find_plt_label_and_element img = 
+let amd64_find_plt_label_and_element img =
     match Map.lookup ".plt" img.elements with
         Nothing -> (* got no PLT? okay... *) Nothing
-        | Just plt_el -> 
+        | Just plt_el ->
             (* Find the PLT tag. *)
             let tags_and_ranges = Multimap.lookupBy Memory_image_orderings.tagEquiv (AbiFeature(Amd64AbiFeature(Abi_amd64.PLT([])))) img.by_tag
             in
@@ -463,24 +463,24 @@ let amd64_find_plt_label_and_element img =
 let got_slot_index_for_symname symname got_label =
     List.findIndex (fun (s, _) -> s = symname) got_label
 
-val amd64_get_reloc_symaddr : symbol_definition -> annotated_memory_image any_abi_feature -> maybe reloc_site -> natural
-let amd64_get_reloc_symaddr the_input_def output_img maybe_reloc = 
+val amd64_get_reloc_symaddr : symbol_definition -> annotated_memory_image any_abi_feature -> list (maybe element_range * symbol_definition) -> maybe reloc_site -> natural
+let amd64_get_reloc_symaddr the_input_def output_img ranges_and_defs maybe_reloc =
     (* The default implementation simply looks up a "matching" symbol in the output image
      * and calculates its address.
-     * 
+     *
      * That's normally fine, even for via-GOT references since their calculations don't
      * use the symaddr. For via-PLT references, we need to use the PLT slot address.
      * HMM. Isn't this duplicating the role of functions like amd64_plt_slot_addr?
-     
-     * Recall that we created this get_reloc_symaddr mechanism to deal with IFUNC symbols. 
+
+     * Recall that we created this get_reloc_symaddr mechanism to deal with IFUNC symbols.
      * With an IFUNC symbol, we reference it simply using a PC32 relocation, but the address
-     * that gets filled in isn't the IFUNC address; it's the corresponding PLT slot. 
+     * that gets filled in isn't the IFUNC address; it's the corresponding PLT slot.
      * HMM: does this happen for other PC32 references? If so, we'll need this mechanism
      * there. And it certainly does, because relocatable object code never uses PLT32
-     * relocs. 
-     * 
+     * relocs.
+     *
      * I had previously tried to handle this issue in mark_fate_of_relocs, using the
-     * 1-argument ApplyReloc(_) and MakePIC to encode the "replacement". But at that stage, 
+     * 1-argument ApplyReloc(_) and MakePIC to encode the "replacement". But at that stage,
      * which is ABI-independent and happens before address assignment?, we can't know enough.
      *)
     (* match bound_def_in_input with
@@ -495,7 +495,7 @@ let amd64_get_reloc_symaddr the_input_def output_img maybe_reloc =
                 | Just (l, plt_el) ->
                 match List.findIndex (fun (symname, _, _) -> symname = the_input_def.def_symname) l with
                     (* FIXME: using symnames seems wrong *)
-                    Just idx -> 
+                    Just idx ->
                         match plt_el.startpos with
                             Just addr -> addr + (naturalFromNat idx) * 16 (* size of a PLT entry *)
                             | Nothing -> failwith "error: PLT has no address assigned"
@@ -503,16 +503,16 @@ let amd64_get_reloc_symaddr the_input_def output_img maybe_reloc =
                     | Nothing -> 0
                 end
             end
-        else default_get_reloc_symaddr the_input_def output_img maybe_reloc
+        else default_get_reloc_symaddr the_input_def output_img ranges_and_defs maybe_reloc
     (* end *)
 
 (* *)
 val amd64_generate_support : (* list (list reloc_site_resolution) -> *) list (string * annotated_memory_image any_abi_feature) -> annotated_memory_image any_abi_feature
-let amd64_generate_support (* reloc_resolution_lists *) input_fnames_and_imgs = 
+let amd64_generate_support (* reloc_resolution_lists *) input_fnames_and_imgs =
     (* We generate a basic GOT. At the moment we can only describe the GOT
      * contents abstractly, not as its binary content, because addresses
-     * have not yet been fixed. 
-     * 
+     * have not yet been fixed.
+     *
      * To do this, we create a set of Abi_amd64.GOTEntry records, one for
      * each distinct symbol that is referenced by one or more GOT-based relocations.
      * To enumerate these, we look at all the symbol refs in the image.
@@ -526,15 +526,15 @@ let amd64_generate_support (* reloc_resolution_lists *) input_fnames_and_imgs =
     ) input_fnames_and_imgs
     in
     let refs_via_got = list_concat_map (fun (i, fname, tags_and_ranges) -> List.mapMaybe (fun (tag, maybe_range) -> match tag with
-         SymbolRef(symref) -> 
+         SymbolRef(symref) ->
             (* Is this ref a relocation we're going to apply, and does it reference the GOT? *)
             match (symref.maybe_reloc, symref.maybe_def_bound_to) with
                 (Nothing, _) -> Nothing
                 | (Just rr, Just(ApplyReloc, maybe_def)) ->
                     if amd64_reloc_needs_got_slot symref rr maybe_def then
-                        (*let _ = errln ("Saw a via-GOT symbol reference: to `" ^ symref.ref.ref_symname ^ "' coming from linkable " ^ (show i) ^ " (" ^ 
+                        (*let _ = errln ("Saw a via-GOT symbol reference: to `" ^ symref.ref.ref_symname ^ "' coming from linkable " ^ (show i) ^ " (" ^
                             fname ^ "), logically from section " ^ (show rr.ref_src_scn)) in *)
-                        Just (symref.ref.ref_symname, maybe_def) 
+                        Just (symref.ref.ref_symname, maybe_def)
                     else Nothing
                 | (Just rr, Just(MakePIC, maybe_def)) -> failwith "FIXME: PIC support please"
             end
@@ -557,19 +557,19 @@ let amd64_generate_support (* reloc_resolution_lists *) input_fnames_and_imgs =
     let got_ifunc_set = { maybe_d | forall (maybe_d IN got_defs_set) | is_ifunc_def maybe_d }
     in
     (* Quirk: what if we have the same def appearing under two different symnames?
-     * This shouldn't happen, at present. 
-     * What if we have the same symname related to two different defs? This also 
+     * This shouldn't happen, at present.
+     * What if we have the same symname related to two different defs? This also
      * shouldn't happen, because only global symbols go in the GOT, so we don't have
-     * to worry about local symbols with the same name as another symbol. But still, it 
+     * to worry about local symbols with the same name as another symbol. But still, it
      * could plausibly happen in some situations with weird symbol visibilities or binding. *)
     (* if Set.size pairs_set <> Set.size defs_set then
         failwith "something quirky going on with GOT symbol defs and their names"
     else *)
-(*    let name_def_pairs = List.foldl (fun acc -> fun (idx, symname, (maybe_range, rr)) -> 
+(*    let name_def_pairs = List.foldl (fun acc -> fun (idx, symname, (maybe_range, rr)) ->
         Set.insert (
-        
+
                 symname, (match rr.maybe_def_bound_to with
-        Map.lookup symname acc with 
+        Map.lookup symname acc with
             Nothing -> [item]
             | Just l -> item :: l
         end) acc) {} refs_via_got
@@ -578,32 +578,32 @@ let amd64_generate_support (* reloc_resolution_lists *) input_fnames_and_imgs =
     in
     let got_entrysize = 8
     in
-    (* We also need a PLT... sort of. We need a way to resolve via-PLT relocs. 
-     * But we might do so without actually creating a (non-zero-length) PLT. 
+    (* We also need a PLT... sort of. We need a way to resolve via-PLT relocs.
+     * But we might do so without actually creating a (non-zero-length) PLT.
      * Again, this is to accommodate the sorts of optimisations the GNU linker does.
-     * 
+     *
      * Note that every PLT entry has a corresponding GOT entry. Here we are simply
      * enumerating the via-PLT relocs that imply a PLT entry. We look their GOT
      * slots up later, by symbol name. *)
     let refs_via_plt = list_concat_map (fun (i, fname, tags_and_ranges) -> List.mapMaybe (fun (tag, maybe_range) -> match tag with
-         SymbolRef(symref) -> 
+         SymbolRef(symref) ->
             (* Is this ref a relocation we're going to apply, and does it reference the GOT? *)
             match (symref.maybe_reloc, symref.maybe_def_bound_to) with
                 (Nothing, _) -> Nothing
                 | (Just rr, Just(ApplyReloc, maybe_def)) ->
                     if amd64_reloc_needs_plt_slot symref rr maybe_def ref_is_statically_linked
-                    then 
+                    then
                         (*let _ = if is_ifunc_def maybe_def then
                          (* we ensure that a PLT entry (specifically .iplt) is generated for the symbol *)
-                         errln ("Saw a reference to IFUNC symbol `" ^ symref.ref.ref_symname ^ "'; ref is coming from linkable " ^ (show i) ^ " (" ^ 
-                            fname ^ "), relent idx " ^ (show rr.ref_rel_idx) ^ " logically from section " ^ (show rr.ref_src_scn) ) 
+                         errln ("Saw a reference to IFUNC symbol `" ^ symref.ref.ref_symname ^ "'; ref is coming from linkable " ^ (show i) ^ " (" ^
+                            fname ^ "), relent idx " ^ (show rr.ref_rel_idx) ^ " logically from section " ^ (show rr.ref_src_scn) )
                         else
-                        errln ("Saw a via-PLT symbol reference: to `" ^ symref.ref.ref_symname ^ "' coming from linkable " ^ (show i) ^ " (" ^ 
-                            fname ^ "), relent idx " ^ (show rr.ref_rel_idx) ^ " logically from section " ^ (show rr.ref_src_scn) ^ 
+                        errln ("Saw a via-PLT symbol reference: to `" ^ symref.ref.ref_symname ^ "' coming from linkable " ^ (show i) ^ " (" ^
+                            fname ^ "), relent idx " ^ (show rr.ref_rel_idx) ^ " logically from section " ^ (show rr.ref_src_scn) ^
                             match maybe_def with Just _ -> ", with definition" | Nothing -> ", not bound to anything" end
                             )
                         in*)
-                        Just(symref.ref.ref_symname, maybe_def) 
+                        Just(symref.ref.ref_symname, maybe_def)
                     else Nothing
                 | (Just rr, Just(MakePIC, maybe_def)) -> failwith "FIXME: PIC support please"
             end
@@ -613,7 +613,7 @@ let amd64_generate_support (* reloc_resolution_lists *) input_fnames_and_imgs =
     (*let _ = errln ("Saw " ^ (show (length refs_via_plt)) ^ " relocations of a via-PLT type")
     in*)
     (* account for the optimisations we did on GOT slots *)
-    let refs_via_plt_having_got_slot = List.mapMaybe (fun (symname, _) -> 
+    let refs_via_plt_having_got_slot = List.mapMaybe (fun (symname, _) ->
         match Map.lookup symname got_idx_and_maybe_def_by_symname_map with
             Just(idx, maybe_d) -> Just (symname, idx, maybe_d)
             | Nothing -> Nothing
@@ -634,7 +634,7 @@ let amd64_generate_support (* reloc_resolution_lists *) input_fnames_and_imgs =
     in
     (*let _ = errln ("We think there should be " ^ (show n_iplt_entries) ^ " PLT entries due to references to IFUNC symbols")
     in*)
-    (* let got_entries_referencing_functions =  (List.filter (fun (symname, maybe_def) -> 
+    (* let got_entries_referencing_functions =  (List.filter (fun (symname, maybe_def) ->
             match def with
                 Just d -> d.def_syment
                 | Nothing -> false
@@ -653,20 +653,20 @@ let amd64_generate_support (* reloc_resolution_lists *) input_fnames_and_imgs =
                  (* header content fn *)
                  (* the header entry is required only for dynamic linking, which is not supported yet *)
                  (* (if plt_needs_header_entry then
-                    ("", Nothing, (((fun (got_base_addr : natural) -> fun (plt_base_addr : natural) -> 
-                     (0, [byte_of_natural 0; byte_of_natural 0; byte_of_natural 0; byte_of_natural 0; 
-                      byte_of_natural 0; byte_of_natural 0; byte_of_natural 0; byte_of_natural 0; 
-                      byte_of_natural 0; byte_of_natural 0; byte_of_natural 0; byte_of_natural 0; 
+                    ("", Nothing, (((fun (got_base_addr : natural) -> fun (plt_base_addr : natural) ->
+                     (0, [byte_of_natural 0; byte_of_natural 0; byte_of_natural 0; byte_of_natural 0;
+                      byte_of_natural 0; byte_of_natural 0; byte_of_natural 0; byte_of_natural 0;
+                      byte_of_natural 0; byte_of_natural 0; byte_of_natural 0; byte_of_natural 0;
                       byte_of_natural 0; byte_of_natural 0; byte_of_natural 0; byte_of_natural 0]))) : plt_entry_content_fn any_abi_feature))
                  else ("", Nothing, (((fun (got_base_addr : natural) -> fun (plt_base_addr : natural) -> (0, []))) : plt_entry_content_fn any_abi_feature))
                  )
                  ++ *) (
                  mapi (fun plt_entry_idx_not_counting_header -> (fun symname ->
-                    (* We want to label the PLT entry with a function that 
+                    (* We want to label the PLT entry with a function that
                      * - accepts the PLT base address, the GOT base address and the GOT slot number;
                      * - closure-captures whatever else it needs (whether we're inserting a PLT header);
-                     * - yields the *full contents of the PLT entry* before relocation. 
-                     * - recall that PLT entries might be "header" (the special one at the start), 
+                     * - yields the *full contents of the PLT entry* before relocation.
+                     * - recall that PLT entries might be "header" (the special one at the start),
                      *      "normal" (to be relocated with R_X86_64_JUMP_SLOT)
                      *   or "irelative" (to be relocated with R_X86_64_IRELATIVE).
                      *    Q. Why are R_X86_64_JUMP_SLOT necessary?
@@ -680,26 +680,26 @@ let amd64_generate_support (* reloc_resolution_lists *) input_fnames_and_imgs =
                         | Nothing -> failwith ("GOT does not contain symbol `" ^ symname ^ "' required by PLT entry")
                         end
                     in
-                    (symname, maybe_def, ((fun (got_base_addr : natural) -> fun (plt_base_addr : natural) -> 
+                    (symname, maybe_def, ((fun (got_base_addr : natural) -> fun (plt_base_addr : natural) ->
                         (* Okay, now we can generate the entry. NOTE that we're lexically still in generate_support,
                          * but we'll be called from concretise_support. The code that generates the header
-                         * entry is actually in concretise_support. 
-                         * 
+                         * entry is actually in concretise_support.
+                         *
                          * If the entry is a normal entry, it looks like
-                         * 
+                         *
                                0x0000000000400410 <+0>:     ff 25 02 0c 20 00       jmpq   *0x200c02(%rip)        # 0x601018 <puts@got.plt>
                                0x0000000000400416 <+6>:     68 00 00 00 00  pushq  $0x0
                                0x000000000040041b <+11>:    e9 e0 ff ff ff  jmpq   0x400400
-                         * 
-                         * If the entry is an irelative entry, it looks like 
-                         * 
+                         *
+                         * If the entry is an irelative entry, it looks like
+                         *
                               400350:       ff 25 02 fd 2b 00       jmpq   *0x2bfd02(%rip)        # 6c0058 <_GLOBAL_OFFSET_TABLE_+0x58>
                               400356:       68 00 00 00 00          pushq  $0x0
                               40035b:       e9 00 00 00 00          jmpq   400360 <check_one_fd.part.0>
-                         
+
                          * ... i.e. basically the same but the pushq and jmpq have literal-zero args (they're not used).
                          *)
-                        let this_plt_slot_base_addr = plt_base_addr + 16 * ((naturalFromNat plt_entry_idx_not_counting_header) 
+                        let this_plt_slot_base_addr = plt_base_addr + 16 * ((naturalFromNat plt_entry_idx_not_counting_header)
                             + if plt_needs_header_entry then 1 else 0)
                         in
                         (*let _ = Missing_pervasives.errln ("PLT slot base address for symname `" ^ symname ^ "': 0x" ^
@@ -717,7 +717,7 @@ let amd64_generate_support (* reloc_resolution_lists *) input_fnames_and_imgs =
                         (*let _ = Missing_pervasives.errln ("PLT's PC-relative index to GOT slot for symname `" ^ symname ^ "' (GOT idx " ^ (show got_slot_idx) ^ ") is (decimal)" ^
                             (show offset_to_got_slot))
                         in*)
-                        let content_bytes = 
+                        let content_bytes =
                         [byte_of_natural 255; byte_of_natural 37] ++ (* offset to the GOT entry, from the *next* instruction start, signed 32-bit LE *)
                             (to_le_signed_bytes 4 offset_to_got_slot) ++
                         [byte_of_natural 104] ++ (* plt slot number not including header, 32-bit LE *)
@@ -734,18 +734,18 @@ let amd64_generate_support (* reloc_resolution_lists *) input_fnames_and_imgs =
                         (*let _ = errln ("Created a PLT entry consisting of " ^ (show (length content_bytes)) ^ " bytes.")
                         in*)
                         (this_plt_slot_base_addr, content_bytes)
-                        (* 
-                        match maybe_def with 
+                        (*
+                        match maybe_def with
                             Nothing -> 0
-                            | Just sd -> 
+                            | Just sd ->
                                 match Memory_image_orderings.find_defs_matching sd img with
                                     [] -> failwith ("no matching definitions for PLT entry named " ^ symname)
-                                    | [(Just(def_el_name, (def_start, def_len)), d)] -> 
+                                    | [(Just(def_el_name, (def_start, def_len)), d)] ->
                                         match element_and_offset_to_address (def_el_name, def_start) img with
                                             Nothing -> failwith ("PLT: no address for definition offset in element " ^ def_el_name)
-                                            | Just x -> 
-                                                let _ = errln ("PLT slot for symbol `" ^ symname ^ 
-                                                    "' calculated at (non-PLT) address 0x" ^ (hex_string_of_natural x) ^ 
+                                            | Just x ->
+                                                let _ = errln ("PLT slot for symbol `" ^ symname ^
+                                                    "' calculated at (non-PLT) address 0x" ^ (hex_string_of_natural x) ^
                                                     " (offset 0x" ^ (hex_string_of_natural def_start) ^ " in element " ^ def_el_name ^ ")")
                                                 in
                                                 x
@@ -754,13 +754,13 @@ let amd64_generate_support (* reloc_resolution_lists *) input_fnames_and_imgs =
                                 end
                         end
                         *)
-                        
+
                     ) : plt_entry_content_fn any_abi_feature))
                 ))
                 plt_symnames)
-            ))) 
+            )))
         )
-    ;   (Just(".plt", (0, 16 * total_n_plt_entries)), FileFeature(ElfSection(1, 
+    ;   (Just(".plt", (0, 16 * total_n_plt_entries)), FileFeature(ElfSection(1,
           <| elf64_section_name = 0 (* ignored *)
            ; elf64_section_type = sht_progbits
            ; elf64_section_flags = shf_alloc
@@ -775,12 +775,12 @@ let amd64_generate_support (* reloc_resolution_lists *) input_fnames_and_imgs =
            ; elf64_section_name_as_string = ".plt"
            |>
         )))
-        (* For each GOT entry that corresponds to a thread-local symbol, we also need to 
-         * generate a relocation record. HMM. These new relocation records are ones we don't 
-         * yet have decisions for. That might be a problem. 
-         * 
+        (* For each GOT entry that corresponds to a thread-local symbol, we also need to
+         * generate a relocation record. HMM. These new relocation records are ones we don't
+         * yet have decisions for. That might be a problem.
+         *
          * In fact, this approach is not appropriate for static linking. Just put the offsets
-         * in there when we concretise the GOT. Something like this will be good for 
+         * in there when we concretise the GOT. Something like this will be good for
          * dynamic linking, though. At the moment, creating a SymbolRef at this stage
          * is problematic because it's not in the bindings list. When we generate shared
          * objects, we'll have to revisit that code. *)
@@ -793,7 +793,7 @@ let amd64_generate_support (* reloc_resolution_lists *) input_fnames_and_imgs =
                 ; maybe_def_bound_to = Just(ApplyReloc, Just sd)
                 ; maybe_reloc = Just(
                   <|
-                        ref_relent  = 
+                        ref_relent  =
                             <| elf64_ra_offset = elf64_addr_of_natural 0
                              ; elf64_ra_info   = elf64_xword_of_natural r_x86_64_tpoff64
                              ; elf64_ra_addend = elf64_sxword_of_integer 0
@@ -803,13 +803,13 @@ let amd64_generate_support (* reloc_resolution_lists *) input_fnames_and_imgs =
                       ; ref_src_scn = 0
                    |>
                 )
-              |>)) 
+              |>))
               | forall ((i, symname, sd) IN (Set.fromList (mapMaybei (fun i -> fun (symname, maybe_def) ->
                 match maybe_def with Nothing -> Nothing | Just sd -> Just(i, symname, sd) end) refs_via_got)))
               | get_elf64_symbol_type sd.def_syment = stt_tls
      *)
     ;   (Just(".got", (0, got_nentries * got_entrysize)), AbiFeature(Amd64AbiFeature(Abi_amd64.GOT(got_pairs_list))))
-    ;   (Just(".got", (0, got_nentries * got_entrysize)), FileFeature(ElfSection(2, 
+    ;   (Just(".got", (0, got_nentries * got_entrysize)), FileFeature(ElfSection(2,
           <| elf64_section_name = 0 (* ignored *)
            ; elf64_section_type = sht_progbits
            ; elf64_section_flags = natural_lor shf_write shf_alloc
@@ -824,7 +824,7 @@ let amd64_generate_support (* reloc_resolution_lists *) input_fnames_and_imgs =
            ; elf64_section_name_as_string = ".got"
            |>
         )))
-    ;   (* FIXME: I've a feeling _GLOBAL_OFFSET_TABLE_ generally doesn't mark the *start* of the GOT; 
+    ;   (* FIXME: I've a feeling _GLOBAL_OFFSET_TABLE_ generally doesn't mark the *start* of the GOT;
          * it's some distance in. What about .got.plt? *)
         (Just(".got", (0, got_nentries * got_entrysize)), SymbolDef(<|
               def_symname = "_GLOBAL_OFFSET_TABLE_"
@@ -839,7 +839,7 @@ let amd64_generate_support (* reloc_resolution_lists *) input_fnames_and_imgs =
             ; def_sym_idx = 1
             ; def_linkable_idx = 0
             |>))
-    ; (Just(".rela.iplt", (0, 24 (* size of an Elf64_Rela *) * naturalFromNat n_iplt_entries)), FileFeature(ElfSection(3, 
+    ; (Just(".rela.iplt", (0, 24 (* size of an Elf64_Rela *) * naturalFromNat n_iplt_entries)), FileFeature(ElfSection(3,
           <| elf64_section_name = 0 (* ignored *)
            ; elf64_section_type = sht_rela
            ; elf64_section_flags = natural_lor shf_alloc shf_info_link
@@ -862,7 +862,7 @@ let amd64_generate_support (* reloc_resolution_lists *) input_fnames_and_imgs =
                ;    contents = []
                |> (Map.insert ".plt" <|
                     startpos = Nothing
-               ;    length = let len = 16 * total_n_plt_entries in 
+               ;    length = let len = 16 * total_n_plt_entries in
                         (*let _ = errln ("PLT length in element: " ^ (show len) ^ " bytes")
                         in *) Just (16 * total_n_plt_entries)
                ;    contents = []
@@ -877,25 +877,27 @@ let amd64_generate_support (* reloc_resolution_lists *) input_fnames_and_imgs =
      |>
 
 val amd64_concretise_support : annotated_memory_image any_abi_feature -> annotated_memory_image any_abi_feature
-let amd64_concretise_support orig_img = 
+let amd64_concretise_support orig_img =
     (*let _ = errln "Concretising amd64 ABI support structures"
     in*)
     (* Fill in the GOT contents. *)
     match amd64_find_got_label_and_element orig_img with
-        Nothing -> orig_img (* no GOT, but that's okay *) 
+        Nothing -> orig_img (* no GOT, but that's okay *)
         | Just (got_l, got_el) ->
     let got_base_addr = match got_el.startpos with
         Just a -> a
         | Nothing -> failwith "GOT has no address assigned"
     end
-    in 
+    in
+    let (ranges_and_defs : list (maybe element_range * symbol_definition)) = Memory_image_orderings.defined_symbols_and_ranges orig_img
+    in
     let got_entry_bytes_for = fun img -> fun symname -> fun maybe_def -> fun plt_l -> fun maybe_plt_el -> match maybe_def with
         Nothing -> replicate 8 (byte_of_natural 0)
         | Just sd ->
-            (* What should the GOT slot be initialized to point to? 
+            (* What should the GOT slot be initialized to point to?
              * If there's a PLT entry, we should point to that + 6,
              * i.e. the second instruction.
-             * 
+             *
              * If there's not, then it might be a thread-local. *)
             match List.findIndex (fun (plt_symname, _, _) -> symname = plt_symname) plt_l with
                 Just plt_slot_idx ->
@@ -907,33 +909,34 @@ let amd64_concretise_support orig_img =
                         | Nothing -> failwith ("no PLT!")
                     end
                     end
-                | Nothing -> 
+                | Nothing ->
                     (* Just look for a definition. *)
-                        match Memory_image_orderings.find_defs_matching sd img with
+                        match Memory_image_orderings.find_defs_matching sd ranges_and_defs with
                         [] -> failwith ("no matching definitions for GOT entry named " ^ symname)
-                        | [(Just(def_el_name, (def_start, def_len)), d)] -> 
+                        | [(Just(def_el_name, (def_start, def_len)), d)] ->
                             match element_and_offset_to_address (def_el_name, def_start) img with
                                 Nothing -> failwith ("no address for definition offset in element " ^ def_el_name)
-                                | Just x -> 
-                                    (* If sd is a TLS symbol, we want its offset from the *end* of the 
+                                | Just x ->
+                                    (* If sd is a TLS symbol, we want its offset from the *end* of the
                                      * TLS segment. *)
                                     (* FIXME: factor out this logic so that it lives in the TLS ABI spec. *)
                                     if get_elf64_symbol_type sd.def_syment = stt_tls then
-                                        (* FIXME: the right way to do this is to mark the segments in the image 
+                                        (* FIXME: the right way to do this is to mark the segments in the image
                                          * *first*. They can't have ranges, because they span many elements,
                                          * but they can have vaddr ranges as arguments. *)
                                         let offs = i2n_signed 64 (0-8)
                                         in
-                                        (*let _ = errln ("GOT slot for TLS symbol `" ^ symname ^ 
+                                        (*let _ = errln ("GOT slot for TLS symbol `" ^ symname ^
                                             "' created containing offset 0x" ^ (hex_string_of_natural offs))
                                         in*)
                                         natural_to_le_byte_list offs
-                                    else (*let _ = errln ("GOT slot for symbol `" ^ symname ^ 
-                                        "' created pointing to address 0x" ^ (hex_string_of_natural x) ^ 
+                                    else (*let _ = errln ("GOT slot for symbol `" ^ symname ^
+                                        "' created pointing to address 0x" ^ (hex_string_of_natural x) ^
                                         " (offset 0x" ^ (hex_string_of_natural def_start) ^ " in element " ^ def_el_name ^ ")")
                                     in*)
                                     natural_to_le_byte_list_padded_to 8 x
                             end
+                        | [(Nothing, _)]  -> failwith ("matching definition for GOT entry named " ^ symname ^ " has no range")
                         | _ -> failwith ("multiple matching definitions for GOT entry named " ^ symname)
                     end
             end
@@ -945,16 +948,16 @@ let amd64_concretise_support orig_img =
         in
         (*let _ = errln ("Concretising a GOT of " ^ (show (length l)) ^ " entries.")
         in*)
-        let got_entry_contents = List.map (fun (symname, maybe_def) -> 
+        let got_entry_contents = List.map (fun (symname, maybe_def) ->
             List.map (fun b -> Just b) (got_entry_bytes_for img symname maybe_def plt_l maybe_plt_el)) l
         in
         (* We replace the GOT element's contents with the concrete addresses
          * of the symbols it should contain. We leave the metadata label in there,
-         * for the relocation logic to find. If we change the order of entries, 
+         * for the relocation logic to find. If we change the order of entries,
          * change it there too. *)
         let got_content = List.concat got_entry_contents
         in
-        let new_got_el = 
+        let new_got_el =
             <| contents = got_content
              ; startpos = got_el.startpos
              ; length   = got_el.length
@@ -982,7 +985,7 @@ let amd64_concretise_support orig_img =
         | Just (plt_l, plt_el) ->
     let plt_base_addr = match plt_el.startpos with
         Just a -> a
-        | Nothing -> failwith "PLT has no address assigned" 
+        | Nothing -> failwith "PLT has no address assigned"
     end
     in
     let concretise_plt = fun img ->
@@ -990,10 +993,10 @@ let amd64_concretise_support orig_img =
        in
         (* We replace the PLT element's contents with the concrete entries
          * for each of the symbols in the table. We leave the metadata label in there,
-         * for the relocation logic to find. If we change the order of entries, 
+         * for the relocation logic to find. If we change the order of entries,
          * change it there too. *)
-        let all_content = concatMap (fun (_, _, plt_content_fn) -> 
-            let (_, content) = plt_content_fn got_base_addr plt_base_addr in 
+        let all_content = concatMap (fun (_, _, plt_content_fn) ->
+            let (_, content) = plt_content_fn got_base_addr plt_base_addr in
             content
         ) l
         in
@@ -1004,7 +1007,7 @@ let amd64_concretise_support orig_img =
             | Nothing -> failwith "PLT has no length"
         end)) ^ " bytes of PLT content")
         in*)
-        let new_plt_el = 
+        let new_plt_el =
             <| contents = List.map (fun b -> Just b) all_content
              ; startpos = plt_el.startpos
              ; length   = Just(length all_content)
@@ -1023,18 +1026,18 @@ let amd64_concretise_support orig_img =
         let maybe_rela_plt_el = Map.lookup ".rela.plt" img.elements
         in
         let maybe_new_rela_plt_el = match maybe_rela_plt_el with
-            Nothing -> (* got no .rela.plt? okay... *) 
+            Nothing -> (* got no .rela.plt? okay... *)
                 (*let _ = errln "No .rela.plt found"
                 in*)
                 Nothing
-            | Just rela_plt_el -> 
+            | Just rela_plt_el ->
                 let got_entry_iplt_widget_for = fun symname -> fun maybe_def -> match maybe_def with
                     Nothing -> Nothing
-                    | Just sd -> 
+                    | Just sd ->
                         if get_elf64_symbol_type sd.def_syment <> stt_gnu_ifunc then Nothing
                         else Just(fun index_in_got ->
                             (* This is a 24-byte Elf64_Rela. *)
-                            let (r_offset : natural) (* GOT *slot* address! *) = 
+                            let (r_offset : natural) (* GOT *slot* address! *) =
                                 match got_el.startpos with
                                     Nothing -> failwith "internal error: GOT has no assigned address"
                                     | Just addr -> addr + (8 * index_in_got)
@@ -1047,13 +1050,13 @@ let amd64_concretise_support orig_img =
                              * NOTE that this is NOT the same as the GOT entry bytes.
                              * It's the actual address of the ifunc, whereas
                              * the GOT entry is initialized to point back into the PLT entry. *)
-                            match Memory_image_orderings.find_defs_matching sd img with
+                            match Memory_image_orderings.find_defs_matching sd ranges_and_defs with
                                   [] -> failwith ("impossible: IPLT entry widget found matching ifunc definition for " ^ symname)
-                                | [(Just(def_el_name, (def_start, def_len)), d)] -> 
+                                | [(Just(def_el_name, (def_start, def_len)), d)] ->
                                     match element_and_offset_to_address (def_el_name, def_start) img with
                                         Nothing -> failwith ("no address for ifunc definition offset in element " ^ def_el_name)
-                                        | Just x -> 
-                                            (* If sd is a TLS symbol, we want its offset from the *end* of the 
+                                        | Just x ->
+                                            (* If sd is a TLS symbol, we want its offset from the *end* of the
                                              * TLS segment. *)
                                             (* FIXME: factor out this logic so that it lives in the TLS ABI spec. *)
                                             if get_elf64_symbol_type sd.def_syment <> stt_gnu_ifunc
@@ -1069,8 +1072,8 @@ let amd64_concretise_support orig_img =
                 in
                 let rela_iplt_widgets = List.map (fun (symname, maybe_def) -> got_entry_iplt_widget_for symname maybe_def) got_l
                 in
-                let new_content_bytelists = 
-                    mapi (fun i -> fun rela_widget -> 
+                let new_content_bytelists =
+                    mapi (fun i -> fun rela_widget ->
                     match rela_widget with
                         Just f -> f (naturalFromNat i)
                         | Nothing -> []
@@ -1105,22 +1108,22 @@ let amd64_concretise_support orig_img =
 end end
 
 val amd64_got_slot_idx : annotated_memory_image any_abi_feature -> symbol_reference_and_reloc_site -> natural
-let amd64_got_slot_idx img rr = 
+let amd64_got_slot_idx img rr =
     (*let _ = errln ("Looking up GOT slot for symbol " ^ rr.ref.ref_symname) in*)
     match Map.lookup ".got" img.elements with
         Nothing -> (* got no GOT? okay... *) failwith "got no GOT"
-        | Just got_el -> 
+        | Just got_el ->
             (* Find the GOT tag. *)
             let tags_and_ranges = Multimap.lookupBy Memory_image_orderings.tagEquiv (AbiFeature(Amd64AbiFeature(Abi_amd64.GOT([])))) img.by_tag
             in
             match tags_and_ranges with
                 [] -> failwith "error: GOT element but no ABI feature GOT tag"
-                | [(AbiFeature(Amd64AbiFeature(Abi_amd64.GOT(l))), Just(got_el_name, (got_start_off, got_len)))] -> 
+                | [(AbiFeature(Amd64AbiFeature(Abi_amd64.GOT(l))), Just(got_el_name, (got_start_off, got_len)))] ->
                     (* Find the slot corresponding to rr, if we have one. *)
                     let got_addr = match got_el.startpos with Just addr -> addr | Nothing -> failwith "GOT has no addr at reloc time" end
                     in
                     match rr.maybe_def_bound_to with
-                        Just (_, Just(d)) -> 
+                        Just (_, Just(d)) ->
                             match List.findIndex (fun (symname, maybe_def) -> Just(d) = maybe_def) l with
                                 Just idx -> naturalFromNat idx
                              |  Nothing -> failwith ("no GOT slot for reloc against `" ^ rr.ref.ref_symname ^ "'")
@@ -1137,16 +1140,16 @@ let amd64_got_slot_idx img rr =
     end
 
 val amd64_got_slot_addr : annotated_memory_image any_abi_feature -> symbol_reference_and_reloc_site -> natural
-let amd64_got_slot_addr img rr = 
+let amd64_got_slot_addr img rr =
     match Map.lookup ".got" img.elements with
         Nothing -> (* got no GOT? okay... *) failwith "got no GOT"
-        | Just got_el -> 
+        | Just got_el ->
             (* Find the GOT tag. *)
             let tags_and_ranges = Multimap.lookupBy Memory_image_orderings.tagEquiv (AbiFeature(Amd64AbiFeature(Abi_amd64.GOT([])))) img.by_tag
             in
             match tags_and_ranges with
                 [] -> failwith "error: GOT element but no ABI feature GOT tag"
-                | [(AbiFeature(Amd64AbiFeature(Abi_amd64.GOT(l))), Just(got_el_name, (got_start_off, got_len)))] -> 
+                | [(AbiFeature(Amd64AbiFeature(Abi_amd64.GOT(l))), Just(got_el_name, (got_start_off, got_len)))] ->
                     (* Find the slot corresponding to rr, if we have one. *)
                     let got_addr = match got_el.startpos with Just addr -> addr | Nothing -> failwith "GOT has no addr at reloc time" end
                     in
@@ -1156,30 +1159,30 @@ let amd64_got_slot_addr img rr =
     end
 
 val amd64_plt_slot_addr : annotated_memory_image any_abi_feature -> symbol_reference_and_reloc_site -> natural -> natural
-let amd64_plt_slot_addr img rr raw_addr = 
+let amd64_plt_slot_addr img rr raw_addr =
     match Map.lookup ".plt" img.elements with
         Nothing ->
-            (* got no PLT? okay... under static linking this can happen. 
+            (* got no PLT? okay... under static linking this can happen.
                We use the actual symbol address of the *)
             (*let _ = errln "Warning: no PLT, so attempting to use actual symbol address as PLT slot address"
-            in*) 
+            in*)
             (* if raw_addr = 0 then failwith "bailing rather than resolving PLT slot to null address (perhaps conservatively)" else  *)
             raw_addr
-        | Just plt_el -> 
+        | Just plt_el ->
             (* Find the PLT tag. *)
             let tags_and_ranges = Multimap.lookupBy Memory_image_orderings.tagEquiv (AbiFeature(Amd64AbiFeature(Abi_amd64.PLT([])))) img.by_tag
             in
             match tags_and_ranges with
                 [] -> failwith "error: PLT element but no ABI feature PLT tag"
-                | [(AbiFeature(Amd64AbiFeature(Abi_amd64.PLT(l))), Just(plt_el_name, (plt_start_off, plt_len)))] -> 
+                | [(AbiFeature(Amd64AbiFeature(Abi_amd64.PLT(l))), Just(plt_el_name, (plt_start_off, plt_len)))] ->
                     let plt_addr = match plt_el.startpos with Just addr -> addr | Nothing -> failwith "PLT has no addr at reloc time" end
                     in
                     (* Find the slot corresponding to rr, if we have one. *)
                     match rr.maybe_def_bound_to with
-                        Just (_, Just(d)) -> 
+                        Just (_, Just(d)) ->
                             match List.mapMaybe (fun (symname, maybe_def, fn) -> if Just(d) = maybe_def then Just fn else Nothing) l with
-                                [fn] -> 
-                                    let got_addr = 
+                                [fn] ->
+                                    let got_addr =
                                          match Map.lookup ".got" img.elements with
                                             Nothing -> (* got no GOT? okay... *) failwith "got no GOT (applying PLT calculation)"
                                             | Just got_el -> match got_el.startpos with
@@ -1195,12 +1198,14 @@ let amd64_plt_slot_addr img rr raw_addr =
                                     in*)
                                     addr
                                 | [] -> (* failwith ("internal error: no PLT entry for reloc against `" ^ rr.ref.ref_symname ^ "'") *)
-                                    (* If we got no PLT slot, we assume it's because the PLT entry was optimised out. 
+                                    (* If we got no PLT slot, we assume it's because the PLT entry was optimised out.
                                      * So we just return the address of the symbol itself. *)
-                                    (*let _ = errln ("No PLT entry for reloc against `" ^ rr.ref.ref_symname ^ 
+                                    (*let _ = errln ("No PLT entry for reloc against `" ^ rr.ref.ref_symname ^
                                         "', which we assume was optimised to avoid the GOT")
                                     in*)
-                                    match Memory_image_orderings.find_defs_matching d img with
+                                    let (ranges_and_defs : list (maybe element_range * symbol_definition)) = defined_symbols_and_ranges img
+                                    in
+                                    match Memory_image_orderings.find_defs_matching d ranges_and_defs with
                                         [] -> 0 (* HMM -- should be an error? *)
                                         | [(Just(el_name, (start_off, len)), matching_d)] ->
                                             match element_and_offset_to_address (el_name, start_off) img with
@@ -1220,7 +1225,7 @@ let amd64_plt_slot_addr img rr raw_addr =
 
 (** [amd64_reloc r] yields a function that applies relocations of type [r]. *)
 val amd64_reloc : reloc_fn any_abi_feature
-let amd64_reloc r = 
+let amd64_reloc r =
     match (string_of_amd64_relocation_type r) with
     | "R_X86_64_NONE" ->            (false, fun img -> (fun site_addr -> (fun rr -> (0, fun s -> fun a -> fun e -> e))))
     | "R_X86_64_64" ->              (true,  fun img -> (fun site_addr -> (fun rr -> (8, fun s -> fun a -> fun e -> i2n (n2i s + a)))))
@@ -1255,11 +1260,11 @@ let amd64_reloc r =
     | "R_X86_64_TLSDESC_CALL" ->    (false, fun img -> (fun site_addr -> (fun rr -> (4 (* CHECK *), fun s -> fun a -> fun e -> e (* FIXME *)))))
     | "R_X86_64_TLSDESC" ->         (false, fun img -> (fun site_addr -> (fun rr -> (8 (* CHECK *), fun s -> fun a -> fun e -> e (* FIXME *)))))
     | "R_X86_64_IRELATIVE" ->       (true,  fun img -> (fun site_addr -> (fun rr -> (8 (* CHECK *), fun s -> fun a -> fun e -> e (* FIXME *)))))
-    | _ -> failwith "unrecognised relocation"
+    | _ -> failwith ("unrecognised relocation " ^ (string_of_amd64_relocation_type r))
 end
 
 val sysv_amd64_std_abi : abi any_abi_feature
-let sysv_amd64_std_abi = 
+let sysv_amd64_std_abi =
    <| is_valid_elf_header = header_is_amd64
     ; make_elf_header = make_elf64_header elf_data_2lsb elf_osabi_none 0 elf_ma_x86_64
     ; reloc = amd64_reloc
@@ -1281,7 +1286,7 @@ let sysv_amd64_std_abi =
     |>
 
 val sysv_aarch64_le_std_abi : abi any_abi_feature
-let sysv_aarch64_le_std_abi = 
+let sysv_aarch64_le_std_abi =
    <| is_valid_elf_header = header_is_aarch64_le
     ; make_elf_header = make_elf64_header elf_data_2lsb elf_osabi_none 0 elf_ma_aarch64
     ; reloc = aarch64_le_reloc
@@ -1303,4 +1308,3 @@ let sysv_aarch64_le_std_abi =
 
 val all_abis : list (abi any_abi_feature)
 let all_abis = [sysv_amd64_std_abi; sysv_aarch64_le_std_abi; null_abi]
-

--- a/src/link.lem
+++ b/src/link.lem
@@ -43,30 +43,30 @@ open import Elf_memory_image
 open import Elf_memory_image_of_elf64_file
 open import Linker_script
 
-let all_common_symbols img = List.filter (fun def -> 
+let all_common_symbols img = List.filter (fun def ->
     natural_of_elf64_half def.def_syment.elf64_st_shndx = shn_common
 ) (elf_memory_image_defined_symbols img)
 
 (* Q. On what does the decision about a reloc depend? definitely on
- * 
+ *
  *      -- command-line options applying to the referenc*ed* object;
- *           (CHECK: I'm inferring that -Bsymbolic, like -Bstatic, applies to the 
+ *           (CHECK: I'm inferring that -Bsymbolic, like -Bstatic, applies to the
  *                   *referenced* object, not the referring -- need experimental conf.)
  *            ACTUALLY, it seems to be global: if a definition goes in the library,
  *                   bind to it; doesn't matter where it comes from. So
- * 
+ *
  *      -- command-line options applying to the output object / whole link (-Bsymbolic);
- * 
+ *
  *      -- command-line options applying to the referencing object?
- * 
- *      What decision can we make?  
- *      Given a reloc, it might be 
+ *
+ *      What decision can we make?
+ *      Given a reloc, it might be
  *      - not bound (weak symbols) -- THIS MEANS it *is* bound but to the value 0!
  *      - bound to a definition
  *
  *      ... perhaps our distinction is between "firm binding or provisional binding"?
  *                                            "final binding or overridable binding"?
- * 
+ *
  *      Can we also hit cases where the binding is final but can't be relocated til load time?
  *      YES, e.g. any final R_*_64_64 reference in a shared library's data segment.
  *      WHAT do we do in these cases? Apply what we can and generate a R_*_RELATIVE?
@@ -80,20 +80,20 @@ let def_is_in_reloc def_item = match def_item with
     | _ -> false
 end
 
-let retrieve_binding_for_ref r r_linkable_idx item bindings_by_name = 
+let retrieve_binding_for_ref r r_linkable_idx item bindings_by_name =
     let maybe_found_bs = Map.lookup r.ref.ref_symname bindings_by_name
-    in 
+    in
     match maybe_found_bs with
-        Nothing -> failwith "impossible: list of bindings does not include symbol reference (map empty)"
+        Nothing -> failwith ("impossible: list of bindings does not include symbol reference `" ^ r.ref.ref_symname ^ "` (map empty)")
             (* FIXME: could this actually be an "undefined symbol" link error perhaps? *)
-        | Just bis_and_bs -> match List.filter (fun (b_idx, ((b_ref_idx, b_ref, b_ref_item), b_maybe_def)) -> 
-            if b_ref_idx = r_linkable_idx && b_ref = r.ref then 
-            (*let _ = Missing_pervasives.errln ("saw ref from linkable idx " ^ (show r_linkable_idx) 
-                ^ ", ref sym scn " ^ (show r.ref.ref_sym_scn) ^ ", ref sym idx "^ (show r.ref.ref_sym_idx) 
+        | Just bis_and_bs -> match List.filter (fun (b_idx, ((b_ref_idx, b_ref, b_ref_item), b_maybe_def)) ->
+            if b_ref_idx = r_linkable_idx && b_ref = r.ref then
+            (*let _ = Missing_pervasives.errln ("saw ref from linkable idx " ^ (show r_linkable_idx)
+                ^ ", ref sym scn " ^ (show r.ref.ref_sym_scn) ^ ", ref sym idx "^ (show r.ref.ref_sym_idx)
                 ^ ", item " ^ (show item) ^ "; binding to " ^ (
                     match b_maybe_def with
-                        Just (def_idx, def, def_item) -> "linkable idx " ^ (show def_idx) ^ 
-                            ", def sym scn " ^ (show def.def_sym_scn) ^ ", def sym idx " ^ 
+                        Just (def_idx, def, def_item) -> "linkable idx " ^ (show def_idx) ^
+                            ", def sym scn " ^ (show def.def_sym_scn) ^ ", def sym idx " ^
                             (show def.def_sym_idx)
                       | Nothing -> "no definition"
                     end
@@ -101,7 +101,7 @@ let retrieve_binding_for_ref r r_linkable_idx item bindings_by_name =
             )
             in*) true
             else false) bis_and_bs with
-                  [] -> failwith "impossible: list of bindings does not include symbol reference (filtered list empty)"
+                  [] -> failwith ("impossible: list of bindings does not include symbol reference `" ^ r.ref.ref_symname ^ "` (filtered list empty)")
                 | [(bi, b)] -> b
                 | _ ->  failwith ("impossible: list of bindings binds reference to symbol `"
                     ^ r.ref.ref_symname ^ "' more than one way (filtered list has >1 element)")
@@ -111,20 +111,20 @@ let retrieve_binding_for_ref r r_linkable_idx item bindings_by_name =
 type reloc_site_resolution = reloc_site * binding * reloc_decision
 
 
-val mark_fate_of_relocs : natural -> abi any_abi_feature -> set Command_line.link_option -> 
+val mark_fate_of_relocs : natural -> abi any_abi_feature -> set Command_line.link_option ->
     binding_map -> linkable_item -> elf_memory_image -> ((list reloc_site_resolution) * elf_memory_image)
-let mark_fate_of_relocs linkable_idx a options bindings_by_name item img = 
+let mark_fate_of_relocs linkable_idx a options bindings_by_name item img =
     (* Our image already models relocation sites. For each relocation *record*,
      * we use our bindings to make a decision about whether to apply it or not.
-     * 
+     *
      * Q1. How do we get the .rela.dyn made? Synthesise a fake reloc section?
      * Or pass them through to the linker script separately?
      * AHA. Note that the script already has an entry for .rela.dyn.
      * And it matches the ordinary rel sections, e.g. .rela.text and so on.
      * So if "-q" is active, the applied relocs need to be injected back in *after* the script
      * has run.
-     * So we need both to materialize some relocs into the script inputs, *and* save some for later. 
-     * 
+     * So we need both to materialize some relocs into the script inputs, *and* save some for later.
+     *
      * Can we just use memory image metadata as the "saved for later" case? YES, I think so.
      * What do we do with metadata that is now being materialized?
      * I think we should only remove the metadata when we apply the relocation.
@@ -135,44 +135,44 @@ let mark_fate_of_relocs linkable_idx a options bindings_by_name item img =
     let building_shared_library = Set.member (Command_line.OutputKind(Command_line.SharedLibrary)) options in
     let bind_functions_early = Set.member Command_line.BindFunctionsEarly options in
     let bind_non_functions_early = Set.member Command_line.BindNonFunctionsEarly options in
-    let (new_by_tag, rev_decisions) = List.foldl (fun (acc_by_tag, rev_acc_decisions) -> (fun (tag, maybe_range) -> 
+    let (new_by_tag, rev_decisions) = List.foldl (fun (acc_by_tag, rev_acc_decisions) -> (fun (tag, maybe_range) ->
         let pass_through = (Set.insert (tag, maybe_range) acc_by_tag, rev_acc_decisions)
         in
-        match tag with 
-            SymbolRef(r) -> 
-                match r.maybe_reloc with 
-                    Just reloc -> 
+        match tag with
+            SymbolRef(r) ->
+                match r.maybe_reloc with
+                    Just reloc ->
                         (* decision: do we want to
                          *  - apply it?   if so, do we need a consequent relocation (e.g. R_*_RELATIVE) in the output?
-                         *  - PICify it, but leave it interposable?    
-                         *  - is "PICified, non-interposable" a thing? I don't think so, because non-interposable bindings are 
+                         *  - PICify it, but leave it interposable?
+                         *  - is "PICified, non-interposable" a thing? I don't think so, because non-interposable bindings are
                                      either intra-object *or* necessarily need load-time relocation to account for load addresses.
                                      In fact ELF can't express "non-interposable inter-object bindings" because we can't name
                                      specific objects when binding symbols.
                          *  - leave it alone, i.e. "relocate at load time"?
-                         * 
-                         * Some useful questions: is the binding final? 
-                         * The GNU linker *never* leaves text relocs alone when generating shared libs; 
+                         *
+                         * Some useful questions: is the binding final?
+                         * The GNU linker *never* leaves text relocs alone when generating shared libs;
                          * it always PICifies them.
                          * It can leave them alone when generating executables, though.
                          * This is an approximation; load-time text relocation can make sense for shared libs.
                          *     (but it's dangerous because PC32 relocs might overflow)
                          *)
                         let (binding_is_final : set Command_line.link_option -> binding -> bool)
-                         = fun options -> (fun ((ref_idx, ref, ref_item), maybe_def) -> 
-                            match maybe_def with 
+                         = fun options -> (fun ((ref_idx, ref, ref_item), maybe_def) ->
+                            match maybe_def with
                                 (* Weak bindings to 0 are final (though libcrunch wishes they weren't!). *)
                                 Nothing -> true
                                 | Just (def_idx, def, def_item) ->
                                     (* Bindings to non-global symbols are final. *)
                                     get_elf64_symbol_binding def.def_syment = stb_local
                                     ||
-                                    (* Bindings to hidden- or protected- or internal-visibility globals 
+                                    (* Bindings to hidden- or protected- or internal-visibility globals
                                      *    are final. *)
                                     Set.member (get_symbol_visibility def.def_syment.elf64_st_info) { stv_hidden; stv_protected; stv_internal }
                                     ||
                                     (* Bindings to global symbols are non-final
-                                     *    *unless* 
+                                     *    *unless*
                                      *      1. the symbol definition is [going to end up] in the executable
                                      *      2. we're -Bsymbolic, outputting a shared object,
                                      *           and the symbol definition is [going to end up] within the same shared object
@@ -184,7 +184,7 @@ let mark_fate_of_relocs linkable_idx a options bindings_by_name item img =
                                     (* 1. *)
                                     (building_executable && def_is_in_reloc def_item) ||
                                     (* 2 and 3. *)
-                                    (building_shared_library && def_is_in_reloc def_item && 
+                                    (building_shared_library && def_is_in_reloc def_item &&
                                         (  ((get_elf64_symbol_type def.def_syment) = stt_func  && bind_functions_early)
                                         || ((get_elf64_symbol_type def.def_syment) <> stt_func && bind_non_functions_early)
                                         )
@@ -193,18 +193,18 @@ let mark_fate_of_relocs linkable_idx a options bindings_by_name item img =
                                      * We don't get inter-object bindings much to non-{default global}s. How much? *)
                             end)
                         in
-                        let (reloc_is_absolute : reloc_site -> bool) = fun rs -> 
-                            let kind = get_elf64_relocation_a_type rs.ref_relent in 
+                        let (reloc_is_absolute : reloc_site -> bool) = fun rs ->
+                            let kind = get_elf64_relocation_a_type rs.ref_relent in
                             let (is_abs, _) = a.reloc kind in
                             is_abs
                         in
-                        (* What's our decision for this reloc? leave, apply, MakePIC? 
+                        (* What's our decision for this reloc? leave, apply, MakePIC?
                          * In fact we return both a decision and a maybe-function to create
-                         * the consequent reloc. 
+                         * the consequent reloc.
                          * In what circumstances do we leave the reloc? If we're making an executable
                                and the definition is not in a relocatable input file or archive or script.
                                Or if we're making a shared library and the reference is "from data".
-                               What does "from data" mean? I think it means it's a PC-relative reloc. 
+                               What does "from data" mean? I think it means it's a PC-relative reloc.
                                If we compile our code to do movabs $addr, even from a *local* address,
                                it's not PIC because that address needs load-time fixup.
                                So actually it's "is absolute address" again.
@@ -222,7 +222,7 @@ let mark_fate_of_relocs linkable_idx a options bindings_by_name item img =
                             (*let _ = errln ("Decided to " ^ match decision with
                                 LeaveReloc -> "leave"
                                 | ApplyReloc -> "apply"
-                            end ^ " relocation in linkable " ^ (show ref_item) ^ "'s image, bound to " ^ 
+                            end ^ " relocation in linkable " ^ (show ref_item) ^ "'s image, bound to " ^
                             match maybe_def with
                                 Just(def_idx, def, def_item) -> "a definition called `" ^ def.def_symname ^ "' in linkable " ^
                                     (show def_item)
@@ -233,14 +233,14 @@ let mark_fate_of_relocs linkable_idx a options bindings_by_name item img =
                             Set.insert (SymbolRef(<|
                                 ref           = r.ref
                                 ; maybe_reloc = r.maybe_reloc
-                                ; maybe_def_bound_to = Just (decision, 
+                                ; maybe_def_bound_to = Just (decision,
                                     match maybe_def with
-                                        Just(def_idx, def, def_item) -> 
+                                        Just(def_idx, def, def_item) ->
                                                 Just <| def_symname = def.def_symname
                                                       ; def_syment  = def.def_syment
                                                       ; def_sym_scn = def.def_sym_scn
                                                       ; def_sym_idx = def.def_sym_idx
-                                                      ; def_linkable_idx = def_idx 
+                                                      ; def_linkable_idx = def_idx
                                                       |>
                                         | Nothing -> Nothing
                                     end
@@ -250,15 +250,15 @@ let mark_fate_of_relocs linkable_idx a options bindings_by_name item img =
                             (reloc, b, decision) :: rev_acc_decisions)
                         in
                         if (building_executable && defined_in_shared_lib)
-                        || (building_shared_library && (reloc_is_absolute reloc)) 
+                        || (building_shared_library && (reloc_is_absolute reloc))
                         then decide LeaveReloc
                         else
                         (* In what circumstances do we apply the reloc? If it's a final binding. *)
                         if binding_is_final options b then decide ApplyReloc
                         (* In what circumstances do we MakePIC? If it's a non-absolute relocatable field
-                         *     and we're building a shared library. 
-                         * 
-                         * PIC is a kind of "consequent relocation", so let's think through it. 
+                         *     and we're building a shared library.
+                         *
+                         * PIC is a kind of "consequent relocation", so let's think through it.
                          * A call site that calls <printf>      will usually be non-final (overridable).
                          * Output needs to call   <printf@plt>. BUT the trick is as follows:
                          *        the reloc is swizzled so that it binds to the PLT slot <printf@plt>;
@@ -270,7 +270,7 @@ let mark_fate_of_relocs linkable_idx a options bindings_by_name item img =
                          * and reproducing their effect using a PLT.
                          * That's why we need this special MakePIC behaviour.
                          * Actually, generalise to a ChangeRelocTo.
-                         * 
+                         *
                          * What about data?
                          * Suppose I have a shared library containing a read-only pointer to <environ>.
                          * The binding is final because <environ> is defined in the executable, say.
@@ -278,16 +278,16 @@ let mark_fate_of_relocs linkable_idx a options bindings_by_name item img =
                          * It's PIC, not PID: data can't be made position-independent.
                          *
                          * So, at least for simple cases of PIC, we don't need consequent relocation if
-                         * we don't apply the reloc. We'll be removing the reloc. But we *do* need to create 
+                         * we don't apply the reloc. We'll be removing the reloc. But we *do* need to create
                          * extra stuff later (PLT, GOT).
                          *)
                         else if building_shared_library then decide (* MakePIC *) (ChangeRelocTo(0, r.ref, reloc)) (* FIXME *)
                         (* The above are non-exclusive and non-exhaustive. Often, more than one option is available,
                          * ABIs / practice makes an arbitrary choice. For example, final bindings
-                         * within a library could be realised the PIC way, but aren't (it'd create a 
+                         * within a library could be realised the PIC way, but aren't (it'd create a
                          * pointless indirection). *)
                         else failwith "didn't know what to do with relocation"
-                    | Nothing -> 
+                    | Nothing ->
                         (* symbol ref with no reloc *)
                         pass_through
                 end
@@ -297,16 +297,16 @@ let mark_fate_of_relocs linkable_idx a options bindings_by_name item img =
     in
     (List.reverse rev_decisions, <| elements = img.elements
       ; by_tag = new_by_tag
-      ; by_range = by_range_from_by_tag new_by_tag 
+      ; by_range = by_range_from_by_tag new_by_tag
       |>)
 
 val strip_metadata_sections : list (reloc_site * binding * reloc_decision) -> abi any_abi_feature -> elf_memory_image -> elf_memory_image
-let strip_metadata_sections reloc_decisions a img = 
+let strip_metadata_sections reloc_decisions a img =
     let (section_tags, section_ranges) = elf_memory_image_section_ranges img
     in
-    let rel_sections = List.mapMaybe (fun (range_tag, (el_name, el_range)) -> 
+    let rel_sections = List.mapMaybe (fun (range_tag, (el_name, el_range)) ->
         match range_tag with
-            FileFeature(ElfSection(idx, isec)) -> 
+            FileFeature(ElfSection(idx, isec)) ->
                 if Set.member isec.elf64_section_type { sht_rel; sht_rela }
                 then Just (idx, isec, el_name)
                 else Nothing
@@ -314,22 +314,22 @@ let strip_metadata_sections reloc_decisions a img =
         end
     ) (zip section_tags section_ranges)
     in
-    let discarded_sections_with_element_name = List.mapMaybe (fun (range_tag, (el_name, el_range)) -> 
+    let discarded_sections_with_element_name = List.mapMaybe (fun (range_tag, (el_name, el_range)) ->
         match range_tag with
-            FileFeature(ElfSection(idx, isec)) -> 
+            FileFeature(ElfSection(idx, isec)) ->
                 if a.section_is_special isec img (* discard reloc sections, and we'll re-add them *)
                 then Just (el_name, range_tag) else Nothing
         end
     ) (zip section_tags section_ranges)
     in
-    let discarded_elements_map = List.foldl (fun m -> (fun (el_name, range_tag) -> 
+    let discarded_elements_map = List.foldl (fun m -> (fun (el_name, range_tag) ->
         (*let _ = errln ("Discarding a metadata element named `" ^ el_name ^ "'") in*)
         Map.insert el_name range_tag m
         )) Map.empty discarded_sections_with_element_name
     in
     let filtered_image = Memory_image.filter_elements (fun (el_name, el) -> not (Map.member el_name discarded_elements_map)) img
     in
-    let new_reloc_section_length = fun idx -> (fun isec -> 
+    let new_reloc_section_length = fun idx -> (fun isec ->
         let retained_relocs_from_this_section = [(reloc, b, decision) | forall ((reloc, b, decision) MEM reloc_decisions)
             | (* is it from this section? *)
               reloc.ref_rel_scn = idx
@@ -342,7 +342,7 @@ let strip_metadata_sections reloc_decisions a img =
         let new_len = new_reloc_section_length idx isec
         in
         let new_el = <| startpos = Nothing ; length = Just new_len; contents = [] |>
-        in 
+        in
         let new_isec =    <| elf64_section_name    = isec.elf64_section_name
                            ; elf64_section_type    = isec.elf64_section_type
                            ; elf64_section_flags   = isec.elf64_section_flags
@@ -355,11 +355,11 @@ let strip_metadata_sections reloc_decisions a img =
                            ; elf64_section_entsize = isec.elf64_section_entsize
                            ; elf64_section_body    = Byte_sequence.empty (* ignored *)
                            ; elf64_section_name_as_string = isec.elf64_section_name_as_string
-                           |> 
+                           |>
         in
         let new_meta = FileFeature(ElfSection(idx, new_isec))
         in
-        ((el_name, new_el), (new_meta, Just(el_name, (0, new_len)))) | forall ((idx, isec, el_name) MEM rel_sections) | new_reloc_section_length idx isec > 0 
+        ((el_name, new_el), (new_meta, Just(el_name, (0, new_len)))) | forall ((idx, isec, el_name) MEM rel_sections) | new_reloc_section_length idx isec > 0
     ]
     in
     let new_by_tag = Set.bigunion { filtered_image.by_tag; Set.fromList new_reloc_tags_and_ranges }
@@ -369,19 +369,19 @@ let strip_metadata_sections reloc_decisions a img =
      ;  by_tag   = new_by_tag
      ;  by_range = by_range_from_by_tag new_by_tag
      |>
-     
 
-let expand_sections_for_one_image a options bindings_by_name linkable_idx item strip_relocs = 
+
+let expand_sections_for_one_image a options bindings_by_name linkable_idx item strip_relocs =
     match item with
-    (RelocELF(img), (fname, blob, origin), input_opts) -> 
-        (*let _ = List.foldl (fun _ -> fun (isec, shndx) ->  
-            let _ = errln ("For file " ^ fname ^ " before stripping, saw section idx " ^ (show shndx) ^ 
+    (RelocELF(img), (fname, blob, origin), input_opts) ->
+        (*let _ = List.foldl (fun _ -> fun (isec, shndx) ->
+            let _ = errln ("For file " ^ fname ^ " before stripping, saw section idx " ^ (show shndx) ^
                 " with name " ^ isec.elf64_section_name_as_string ^ ", first 20 bytes: " ^ (show (take 20 (
                     (let maybe_elname = elf_memory_image_element_coextensive_with_section shndx img
                      in
                      match maybe_elname with
                         Nothing -> failwith ("impossible: no such section (" ^ (show shndx) ^ ") in image of " ^ fname)
-                        | Just idstr -> 
+                        | Just idstr ->
                             match Map.lookup idstr img.elements with
                                 Just el -> el.contents
                                 | Nothing -> failwith "no such element"
@@ -393,44 +393,44 @@ let expand_sections_for_one_image a options bindings_by_name linkable_idx item s
             ) () (elf_memory_image_sections_with_indices img)
         in*)
         let ((reloc_decisions : list (reloc_site * binding * reloc_decision)), marked_img) = mark_fate_of_relocs linkable_idx a options bindings_by_name item img
-        in 
+        in
         (* Now we have a decision for each reloc: Leave, Apply, MakePIC. Which ones
-         * do we materialize? Only the Leave ones, for now. To support -q we'll 
+         * do we materialize? Only the Leave ones, for now. To support -q we'll
          * have to support tweaking this.
-         * 
-         * For each relocation that we Leave, we figure out its originating section 
-         * and re-create a lookalike in the memory image. 
-         * 
-         * We also get called for the "generated" memory image that contains .plt, 
+         *
+         * For each relocation that we Leave, we figure out its originating section
+         * and re-create a lookalike in the memory image.
+         *
+         * We also get called for the "generated" memory image that contains .plt,
          * .rela.plt and so on. We don't strip these, since they actually contain relocs
          * that need to go directly into the output file. That's what the strip_relocs
          * argument is for. FIXME: refactor this into two functions.
          *)
         let stripped_img_with_reloc_sections = if strip_relocs
             then (*let _ = errln ("Discarding metadata sections from image of `" ^ fname ^ "'") in*)
-            strip_metadata_sections reloc_decisions a marked_img 
+            strip_metadata_sections reloc_decisions a marked_img
             else marked_img
         in
-        (* Now we have a whole new image! It differs from the old one in that 
+        (* Now we have a whole new image! It differs from the old one in that
          * - non-special sections have been stripped
          * - the relocs we want to participate in linking have been materialized.
          *)
-        (* The "-q" option is tricky. It causes all incoming relocs to be retained, but 
+        (* The "-q" option is tricky. It causes all incoming relocs to be retained, but
          * they *don't* participate in linking -- notice that the default linker script
          * pulls all .rela.* sections into .rela.dyn, whereas these ones *don't* go in there.
-         * So FIXME: to support this, we need a way to re-add them, probably when we 
+         * So FIXME: to support this, we need a way to re-add them, probably when we
          * generate meta-output like .symtab etc.. *)
-        let inputs = 
+        let inputs =
         [
             let short_name = short_string_of_linkable_item item
             in
-            (*let _ = errln ("For file " ^ short_name ^ " after stripping, saw section idx " ^ (show shndx) ^ 
+            (*let _ = errln ("For file " ^ short_name ^ " after stripping, saw section idx " ^ (show shndx) ^
                 " with name " ^ isec.elf64_section_name_as_string ^ ", first 20 bytes: " ^ (show (take 20 (
                     (let maybe_elname = elf_memory_image_element_coextensive_with_section shndx stripped_img_with_reloc_sections
                      in
                      match maybe_elname with
                         Nothing -> failwith ("impossible: no such section (matching " ^ (show shndx) ^ ")")
-                        | Just idstr -> 
+                        | Just idstr ->
                             match Map.lookup idstr stripped_img_with_reloc_sections.elements with
                                 Just el -> el.contents
                                 | Nothing -> failwith "no such element"
@@ -438,7 +438,7 @@ let expand_sections_for_one_image a options bindings_by_name linkable_idx item s
                     end
                     )))))
             in*)
-        InputSection(<| 
+        InputSection(<|
             idx   = linkable_idx
         ;   fname = short_name
         ;   img   = stripped_img_with_reloc_sections
@@ -448,8 +448,8 @@ let expand_sections_for_one_image a options bindings_by_name linkable_idx item s
          |>) | forall ((isec, shndx) MEM elf_memory_image_sections_with_indices stripped_img_with_reloc_sections) | true (* not (a.section_is_special isec img *)
         ]
         ++ (
-        (* One item per common symbol. FIXME: what about common symbols that have the same name? 
-         * We need to explicitly instantiate common symbols somewhere, probably here. 
+        (* One item per common symbol. FIXME: what about common symbols that have the same name?
+         * We need to explicitly instantiate common symbols somewhere, probably here.
          * This means dropping any that are unreferenced (does it?) and merging any multiply-defined.
          * Actually, we deal with section merging at the same time as section concatenation, so during
          * linker script processing. For discarding unused common symbols, I *think* that this has already
@@ -458,13 +458,13 @@ let expand_sections_for_one_image a options bindings_by_name linkable_idx item s
         in
         (*let _ = errln ("Expanding " ^ (show (length common_symbols)) ^ " common symbols")
         in*)
-        [Common(linkable_idx, fname, stripped_img_with_reloc_sections, def) | forall (def MEM common_symbols) | 
+        [Common(linkable_idx, fname, stripped_img_with_reloc_sections, def) | forall (def MEM common_symbols) |
             (*let _ = Missing_pervasives.outln ((space_padded_and_maybe_newline 20 def.def_symname)
                 ^ (let hexstr = "0x" ^ (hex_string_of_natural (natural_of_elf64_xword def.def_syment.elf64_st_size))
                   in
                   space_padded_and_maybe_newline 20 hexstr
                   )
-                ^ 
+                ^
                 fname)
             in*)
             true
@@ -477,14 +477,14 @@ end
 type reloc_resolution = reloc_site * binding * reloc_decision
 
 val default_merge_generated : abi any_abi_feature -> elf_memory_image -> list (list Linker_script.input_spec) -> list (list Linker_script.input_spec)
-let default_merge_generated a generated_img input_spec_lists = 
+let default_merge_generated a generated_img input_spec_lists =
     (* We expand the sections in the generated image and hang them off
-     * the first linkable item. *) 
-    (*let _ = errln ("Generated image has " ^ (show (Map.size generated_img.elements)) ^ " elements and " ^ (show (Set.size (generated_img.by_tag))) ^ 
+     * the first linkable item. *)
+    (*let _ = errln ("Generated image has " ^ (show (Map.size generated_img.elements)) ^ " elements and " ^ (show (Set.size (generated_img.by_tag))) ^
         " metadata elements (sanity: " ^ (show (Set.size (generated_img.by_range))) ^ ")")
     in*)
     let dummy_input_item = ("(no file)", Input_list.Reloc(Sequence([])), ((Command_line.File(Command_line.Filename("(no file)"), Command_line.null_input_file_options)), [InCommandLine(0)]))
-    in 
+    in
     let dummy_linkable_item = (RelocELF(generated_img), dummy_input_item, Input_list.null_input_options)
     in
     let (_, _, generated_inputs) = expand_sections_for_one_image a {} Map.empty 0 dummy_linkable_item false
@@ -499,28 +499,28 @@ let default_merge_generated a generated_img input_spec_lists =
     (* input_spec_lists *)
 
 val expand_sections_for_all_inputs : abi any_abi_feature -> set Command_line.link_option -> binding_map ->
-    (abi any_abi_feature -> elf_memory_image -> list (list Linker_script.input_spec) -> list (list Linker_script.input_spec)) (* merge_generated *) -> 
-    list (natural * Linkable_list.linkable_item) -> 
+    (abi any_abi_feature -> elf_memory_image -> list (list Linker_script.input_spec) -> list (list Linker_script.input_spec)) (* merge_generated *) ->
+    list (natural * Linkable_list.linkable_item) ->
     list (list reloc_resolution * elf_memory_image * list Linker_script.input_spec)
-let expand_sections_for_all_inputs a options bindings_by_name merge_generated idx_and_linkables = 
-    let (expanded_reloc_lists, expanded_imgs, linker_script_input_lists) = unzip3 (List.map (fun (idx, linkable) -> 
+let expand_sections_for_all_inputs a options bindings_by_name merge_generated idx_and_linkables =
+    let (expanded_reloc_lists, expanded_imgs, linker_script_input_lists) = unzip3 (List.map (fun (idx, linkable) ->
         expand_sections_for_one_image a options bindings_by_name idx linkable true) idx_and_linkables)
     in
     let fnames = List.map (fun (idx, (_, (fname, _, _), _)) -> fname) idx_and_linkables
     in
-    (* We pass the collection of linkable images and reloc decision lists 
-     * to an ABI tap function. 
-     * 
+    (* We pass the collection of linkable images and reloc decision lists
+     * to an ABI tap function.
+     *
      * This returns us a new *image* containing all the elements. Logically
      * this is another participant in the link, which we could expand separately.
-     * A personality function takes care of actually merging it back into the 
+     * A personality function takes care of actually merging it back into the
      * linker script inputs... in the case of the GNU linker, this means pretending
      * the generated stuff came from the first input object.
      *)
     let generated_img = a.generate_support (* expanded_relocs *) (zip fnames expanded_imgs)
     in
-    (* We need to return a 
-     * 
+    (* We need to return a
+     *
      *    list (list reloc_decision * elf_memory_image * list Linker_script.input_spec)
      *
      * i.e. one item for every input image. *)
@@ -529,20 +529,20 @@ let expand_sections_for_all_inputs a options bindings_by_name merge_generated id
     zip3 expanded_reloc_lists expanded_imgs final_input_spec_lists
 
 val relocate_output_image : abi any_abi_feature -> map string (list (natural * binding)) -> elf_memory_image -> elf_memory_image
-let relocate_output_image a bindings_by_name img = 
+let relocate_output_image a bindings_by_name img =
     let relocs = Multimap.lookupBy Memory_image_orderings.tagEquiv (SymbolRef(null_symbol_reference_and_reloc_site))
         img.by_tag
     in
-    
-    (*let _ = errln ("For __libc_multiple_threads (in relocate_output_image), we have " ^ 
+
+    (*let _ = errln ("For __libc_multiple_threads (in relocate_output_image), we have " ^
         (let all_bs = match Map.lookup "__libc_multiple_threads" bindings_by_name with
             Just l -> l
             | Nothing -> []
         end
         in
-        ((show (length all_bs)) ^ 
-        " bindings, of which " ^ 
-        (show (length (List.filter (fun (bi, ((ref_idx, ref, ref_item), maybe_def)) -> 
+        ((show (length all_bs)) ^
+        " bindings, of which " ^
+        (show (length (List.filter (fun (bi, ((ref_idx, ref, ref_item), maybe_def)) ->
             match maybe_def with
                 Just _ -> true
                 | _ -> false
@@ -590,16 +590,18 @@ let relocate_output_image a bindings_by_name img =
          |>
     )
     in
+    let (ranges_and_defs : list (maybe element_range * symbol_definition)) = Memory_image_orderings.defined_symbols_and_ranges img
+    in
     let relocated_img = List.foldl (fun acc_img -> (fun (tag, maybe_range) ->
-        match tag with 
+        match tag with
             SymbolRef(x) -> match x.maybe_reloc with
-                Just rs -> 
+                Just rs ->
                     match maybe_range with
                         Nothing -> failwith "impossible: reloc site with no range"
-                        | Just (el_name, (start, len)) -> 
+                        | Just (el_name, (start, len)) ->
                             (*let _ = errln ("During relocation, saw a reloc site in element " ^ el_name ^ ", offset 0x" ^
-                                (hex_string_of_natural start) ^ ", length 0x" ^ (hex_string_of_natural len) ^ 
-                                ", reloc type " ^ (* a. *) Abi_amd64_relocation.string_of_amd64_relocation_type (get_elf64_relocation_a_type rs.ref_relent) ^ 
+                                (hex_string_of_natural start) ^ ", length 0x" ^ (hex_string_of_natural len) ^
+                                ", reloc type " ^ (* a. *) Abi_amd64_relocation.string_of_amd64_relocation_type (get_elf64_relocation_a_type rs.ref_relent) ^
                                 ", symbol name `" ^ x.ref.ref_symname ^ "'")
                             in*)
                             let symaddr = match x.maybe_def_bound_to with
@@ -615,9 +617,9 @@ let relocate_output_image a bindings_by_name img =
                                      * a matching symbol and use its address. But ABIs can do
                                      * wacky things if they like.
                                      *)
-                                    a.get_reloc_symaddr bound_def img x.maybe_reloc
+                                    a.get_reloc_symaddr bound_def img ranges_and_defs x.maybe_reloc
                                 | Nothing -> failwith "no def found for bound-to symbol"
-                                | Just(ApplyReloc, Nothing) -> 
+                                | Just(ApplyReloc, Nothing) ->
                                     (*let _ = errln "No definition, so we think this is a weak reference; giving it value 0."
                                     in*)
                                     (* CHECK: does the syment say it's weak? *)
@@ -625,9 +627,9 @@ let relocate_output_image a bindings_by_name img =
                                         (*let _ = errln "Actually not weak! bailing"
                                         in*)
                                         failwith "not a weak reference, but no binding"
-                                    else 
+                                    else
                                     (* Weak symbol. *) 0
-                                | Just(LeaveReloc, _) -> 
+                                | Just(LeaveReloc, _) ->
                                     (* We shouldn't be seeing this, given that we're applying the reloc Right Now. *)
                                     failwith "internal error: applying reloc that is not to be applied"
                             end
@@ -645,9 +647,9 @@ let relocate_output_image a bindings_by_name img =
     relocated_img
 
 val link : address_expr_fn_map allocated_sections_map -> linker_control_script -> abi any_abi_feature -> set Command_line.link_option -> linkable_list -> elf_memory_image
-let link alloc_map script a options linkables = 
-    let initial_included_indices = mapMaybei (fun i -> (fun (obj, inp, (opts : input_options)) -> 
-        if opts.item_force_output 
+let link alloc_map script a options linkables =
+    let initial_included_indices = mapMaybei (fun i -> (fun (obj, inp, (opts : input_options)) ->
+        if opts.item_force_output
         then Just i
         else Nothing
     )) linkables
@@ -660,14 +662,14 @@ let link alloc_map script a options linkables =
      = (* accumulate_bindings_bf a linkables defmap {} initial_included_indices []  *)
           accumulate_bindings_objectwise_df a linkables defmap [] {} initial_included_indices
     in
-    (* Keep a map whose keys are referenced objects, and whose values are 
+    (* Keep a map whose keys are referenced objects, and whose values are
      * *some* (diagnostic purposes only) reference to that linkable. *)
-    let referenced_object_indices_and_reasons = List.foldl (fun acc_m -> (fun ((ref_idx, ref_sym, ref_linkable), maybe_def_idx_and_sym_and_linkable) -> 
+    let referenced_object_indices_and_reasons = List.foldl (fun acc_m -> (fun ((ref_idx, ref_sym, ref_linkable), maybe_def_idx_and_sym_and_linkable) ->
         match maybe_def_idx_and_sym_and_linkable with
             Nothing -> acc_m
-            | Just (def_idx, def_sym, def_linkable) -> 
+            | Just (def_idx, def_sym, def_linkable) ->
                 (* Make sure the map contains this key. *)
-                if Map.lookup def_idx acc_m = Nothing 
+                if Map.lookup def_idx acc_m = Nothing
                     then Map.insert def_idx (ref_sym, ref_linkable) acc_m
                     else acc_m
         end
@@ -675,7 +677,7 @@ let link alloc_map script a options linkables =
     in
     (* Print something similar to GNU ld's linker map output, about included archive members. *)
     (*let _ = Missing_pervasives.outln "Archive member included to satisfy reference by file (symbol)\n" in*)
-    let linkables_not_discarded = mapMaybei (fun i -> (fun (obj, inp, opts) -> 
+    let linkables_not_discarded = mapMaybei (fun i -> (fun (obj, inp, opts) ->
         let referenced_object_map_entry = Map.lookup i referenced_object_indices_and_reasons
         in
         let referenced = (referenced_object_map_entry <> Nothing)
@@ -702,7 +704,7 @@ let link alloc_map script a options linkables =
                             else makeString (30 - lhs_name_len) #' '
                         in
                         Missing_pervasives.outln (
-                            lhs_name ^ spacing ^ 
+                            lhs_name ^ spacing ^
                             (match ref_origin with
                                 (_, InArchive(bid, bidx, bname, _) :: _) -> bname ^ "(" ^ ref_name ^ ")"
                                 | _ -> ref_name
@@ -713,24 +715,24 @@ let link alloc_map script a options linkables =
                 end
         )
         in*)
-        if referenced || opts.item_force_output 
+        if referenced || opts.item_force_output
         then Just (i, (obj, inp, opts))
         else Nothing
     )) linkables
     in
     (*let _ = Missing_pervasives.outln "\nAllocating common symbols\nCommon symbol       size              file\n"
     in*)
-    (* We have to do a pass over relocations quite early. This is because relocs *do* participate 
+    (* We have to do a pass over relocations quite early. This is because relocs *do* participate
      * in linking. For each reloc, we need to decide whether to apply it or not. For those not applied,
-     * we include it in a synthesised section that participates in linking. 
-     * 
-     * Similarly, the GOT needs to participate in linking, so that it gets assigned an address 
-     * at the appropriate place (as determined by the script). So we have to generate the GOT 
-     * *before* running the linker script. The GNU linker hangs the whole GOT and PLT content 
-     * off the first input object (usually crt1.o). In general, expand_sections calls an ABI tap 
-     * which synthesises all the necessary things, like (in the GNU case) the .got and .plt sections 
+     * we include it in a synthesised section that participates in linking.
+     *
+     * Similarly, the GOT needs to participate in linking, so that it gets assigned an address
+     * at the appropriate place (as determined by the script). So we have to generate the GOT
+     * *before* running the linker script. The GNU linker hangs the whole GOT and PLT content
+     * off the first input object (usually crt1.o). In general, expand_sections calls an ABI tap
+     * which synthesises all the necessary things, like (in the GNU case) the .got and .plt sections
      * hanging off the first input object. *)
-    let (initial_bindings_by_name : Map.map string (list (natural * binding))) = 
+    let (initial_bindings_by_name : Map.map string (list (natural * binding))) =
         List.foldl (fun m -> fun (b_idx, ((ref_idx, ref, ref_item), maybe_def)) -> match Map.lookup ref.ref_symname m with
             Nothing                  -> Map.insert ref.ref_symname [ (b_idx, ((ref_idx, ref, ref_item), maybe_def)) ] m
             | Just ((bi, b) :: more) -> Map.insert ref.ref_symname  ((b_idx, ((ref_idx, ref, ref_item), maybe_def)) :: (bi, b) :: more) m
@@ -746,14 +748,14 @@ let link alloc_map script a options linkables =
     in
     let seen_ordering = fun is1 -> (fun is2 -> (
         let toNaturalList = fun is -> (
-            (* We're mapping the item to a list of naturals that determine a 
+            (* We're mapping the item to a list of naturals that determine a
              * lexicographic order. The list has a fixed depth:
-             * 
+             *
              * [within-commandline, within-group, within-archive, section-or-symbol]
-             * 
+             *
              * For .o files on the command line, we use the command line order. This
              * is the first level in the hierarchy.
-             *  
+             *
              * For .a files with --whole-archive, we want to do the same. Do this
              * by using archive position as the second level of the hierarchy, *if*
              * the item is marked as force_output.
@@ -765,21 +767,21 @@ let link alloc_map script a options linkables =
              * i.e. so that "force_output" makes an element appear sooner. In practice
              * we won't get a mixture of force_output and non- in the same archive,
              * so each archive will use only one of the two orderings.
-             * 
+             *
              * How do sections order relative to common symbols? Again, in practice it
              * doesn't matter because no input query will get a mixture of the two.
              * For symbols, we start the numbering from the number of sections in the file,
              * so symbols always appear later in the sortd order.
              *)
             let (linkable_idx, section_or_symbol_idx) = match is with
-                Common(idx, fname, img, def) -> (idx, 
+                Common(idx, fname, img, def) -> (idx,
                     (let (_, l) = (elf_memory_image_section_ranges img) in length l) + def.def_sym_idx)
                 | InputSection(isrec) -> (isrec.idx, isrec.shndx)
             end
             in
             match List.index linkables (unsafe_nat_of_natural linkable_idx) with
                 Nothing -> failwith "impossible: linker input not in linkables list"
-                | Just (obj, (fname, blob, (inp_unit, coords)), options) -> 
+                | Just (obj, (fname, blob, (inp_unit, coords)), options) ->
                     let (our_cid, our_gid, our_aid, maybe_archive_size) = match coords with
                       InArchive(aid, aidx, _, asize) :: InGroup(gid, gidx) :: [InCommandLine(cid)] -> (cid, gid, aid, Just asize)
                     | InArchive(aid, aidx, _, asize) :: [InCommandLine(cid)]                       -> (cid, 0, aid,   Just asize)
@@ -794,7 +796,7 @@ let link alloc_map script a options linkables =
                             Nothing -> failwith "impossible: archive with no size"
                             | Just a -> a
                         end
-                        in archive_size + 
+                        in archive_size +
                         (* search the bindings: we want the index of the first binding
                            that refers to this object.
                          *)
@@ -815,7 +817,7 @@ let link alloc_map script a options linkables =
     ))
     in
     (*
-    let get_binding_for_ref = (fun symref -> (fun linkable_idx -> (fun fname -> 
+    let get_binding_for_ref = (fun symref -> (fun linkable_idx -> (fun fname ->
         let name_matches = match Map.lookup symref.ref_symname bindings_by_name with Just x -> x | Nothing -> [] end
         in
         match List.filter (fun (bi, ((r_idx, r, r_item), m_d)) -> r_idx = linkable_idx && r = symref) name_matches with
@@ -831,7 +833,7 @@ let link alloc_map script a options linkables =
     in
     (* also copy over ABS (range-less) symbols from all included input items *)
     let all_abs_range_tags_in_included_inputs = List.concat (
-        List.map (fun (img, (idx, linkable)) -> 
+        List.map (fun (img, (idx, linkable)) ->
           let abslist = List.mapMaybe (fun (tag, maybeRange) ->
             match tag with
                 SymbolDef(ent) -> if maybeRange = Nothing && natural_of_elf64_half ent.def_syment.elf64_st_shndx = shn_abs
@@ -841,8 +843,8 @@ let link alloc_map script a options linkables =
             end
           ) (tagged_ranges_matching_tag (SymbolDef(null_symbol_definition)) img)
           in
-          (*let _ = errln ("Copying " ^ (show (length abslist)) ^ " ABS symbols (names: " ^ 
-            List.foldl (fun acc -> fun str -> if stringLength acc = 0 then str else acc ^ ", " ^ str) "" 
+          (*let _ = errln ("Copying " ^ (show (length abslist)) ^ " ABS symbols (names: " ^
+            List.foldl (fun acc -> fun str -> if stringLength acc = 0 then str else acc ^ ", " ^ str) ""
                 (List.map (fun (_, x) -> x.def_symname) abslist)
             ^ ") from not-discarded linkable item " ^
             (short_string_of_linkable_item linkable))
@@ -851,12 +853,12 @@ let link alloc_map script a options linkables =
                                      ; def_syment  = ent.def_syment
                                      ; def_sym_scn = ent.def_sym_scn
                                      ; def_sym_idx = ent.def_sym_idx
-                                     ; def_linkable_idx = idx 
+                                     ; def_linkable_idx = idx
                                      |>)) | forall ((maybe_range, ent) MEM abslist) | true ]
         ) (zip imgs linkables_not_discarded)
     )
     in
-    let by_range_including_abs_symbols = 
+    let by_range_including_abs_symbols =
         unrelocated_output_image_lacking_abs_symbols.by_range
         union
         (Set.fromList all_abs_range_tags_in_included_inputs)
@@ -866,8 +868,8 @@ let link alloc_map script a options linkables =
     ;   by_range = by_range_including_abs_symbols
     ;   by_tag   = by_tag_from_by_range by_range_including_abs_symbols
     |>
-    (* This image has 
-     * - addresses assigned 
+    (* This image has
+     * - addresses assigned
      * - relocations *not* applied
      * - no entry point
      * - some ABI features not generated? GOT, certainly. HMM.
@@ -880,14 +882,14 @@ let link alloc_map script a options linkables =
         unrelocated_output_image.by_tag
     in
     let _ = List.foldl (fun _ -> (fun (tag, maybe_range) ->
-        let _ = match tag with 
+        let _ = match tag with
             SymbolRef(x) -> match x.maybe_reloc with
-                Just rs -> 
+                Just rs ->
                     match maybe_range with
                         Nothing -> failwith "impossible: reloc site with no range"
-                        | Just (el_name, (start, len)) -> 
+                        | Just (el_name, (start, len)) ->
                             () (* errln ("After linking, saw a reloc site in element " ^ el_name ^ ", offset 0x" ^
-                                (hex_string_of_natural start) ^ ", length 0x" ^ (hex_string_of_natural len) ^ 
+                                (hex_string_of_natural start) ^ ", length 0x" ^ (hex_string_of_natural len) ^
                                 ", reloc type " ^ Abi_amd64_relocation.string_of_amd64_relocation_type (get_elf64_relocation_a_type rs.ref_relent)) *)
                     end
                 | Nothing -> (* okay, do nothing *) ()
@@ -904,25 +906,25 @@ let link alloc_map script a options linkables =
     in
     let output_image = relocate_output_image a bindings_by_name unrelocated_concrete_output_image
     in
-    let (maybe_entry_point_address : maybe natural) = 
+    let (maybe_entry_point_address : maybe natural) =
         match Command_line.find_option_matching_tag (Command_line.EntryAddress(0)) options with
             Nothing -> a.guess_entry_point output_image
             | Just(Command_line.EntryAddress(x)) -> Just x
         end
     in
     match maybe_entry_point_address with
-        Just addr -> 
+        Just addr ->
             match address_to_element_and_offset addr output_image with
-                Just (el_name, el_offset) -> 
+                Just (el_name, el_offset) ->
                     (*let _ = errln ("Tagging element " ^ el_name ^ " as containing entry point at offset 0x" ^ (hex_string_of_natural el_offset))
                     in*)
                     tag_image (EntryPoint) el_name el_offset 0 output_image
-                | Nothing -> 
+                | Nothing ->
                     (* HMM. entry point symbol has no address at present. *)
                     failwith ("error: entry point address 0x" ^ (hex_string_of_natural addr) ^ " does not correspond to any element position")
             end
-        | Nothing -> 
-            (*let _ = errln "Warning: not tagging entry point in output image"
-            in*) 
+        | Nothing ->
+            let _ = errln "Warning: not tagging entry point in output image"
+            in
             output_image
     end

--- a/src/linkable_list.lem
+++ b/src/linkable_list.lem
@@ -54,7 +54,7 @@ end
 type linkable_item = linkable_object * input_item * input_options
 
 val short_string_of_linkable_item : linkable_item -> string
-let short_string_of_linkable_item item = 
+let short_string_of_linkable_item item =
     let (obj, inp, opts) = item
     in
     short_string_of_input_item inp
@@ -78,16 +78,16 @@ let image_of_linkable_item item = match item with
 end
 
 val linkable_item_of_input_item_and_options : forall 'abifeature. abi 'abifeature -> input_item -> input_options -> linkable_item
-let linkable_item_of_input_item_and_options a it opts = 
+let linkable_item_of_input_item_and_options a it opts =
     match (match it with
-        (fname, Reloc(seq), origin) -> 
-            (*let _ = Missing_pervasives.errln ("Considering relocatable file " ^ fname) in*)
+        (fname, Reloc(seq), origin) ->
+            let _ = Missing_pervasives.errln ("Considering relocatable file " ^ fname) in
             Elf_file.read_elf64_file seq >>= fun e ->
             return (RelocELF(elf_memory_image_of_elf64_file a fname e), it, opts)
-        | (fname, Shared(seq), origin) -> 
+        | (fname, Shared(seq), origin) ->
             (*let _ = Missing_pervasives.errln ("Skipping shared object " ^ fname) in *)
             fail "unsupported input item"
-        | (fname, Script(seq), origin) -> 
+        | (fname, Script(seq), origin) ->
             (*let _ = Missing_pervasives.errln ("Skipping linker script " ^ fname) in*)
             fail "unsupported input item"
         end)
@@ -97,15 +97,15 @@ let linkable_item_of_input_item_and_options a it opts =
     end
 
 val string_of_linkable : linkable_item -> string
-let {ocaml} string_of_linkable l = match l with 
+let {ocaml} string_of_linkable l = match l with
     (_, item, _) -> show item
 end
 
-(* How do we signal "multiple definitions"? 
+(* How do we signal "multiple definitions"?
  * This is part of the policy baked into the particular oracle:
  * are multiple definitions okay, or do we fail?
- * 
- * NOTE that multiple definitions *globally* is not the same as 
+ *
+ * NOTE that multiple definitions *globally* is not the same as
  * multiple definitions as candidates for a given binding. We
  * can get the former even if we don't have the latter, in some
  * weird group/archive arrangements. The right place to detect
@@ -114,7 +114,7 @@ end
 
 val add_definition_to_map : (natural * symbol_definition * linkable_item) -> Map.map string (list (natural * symbol_definition * linkable_item))
                     -> Map.map string (list (natural * symbol_definition * linkable_item))
-let add_definition_to_map def_idx_and_def_and_linkable m = 
+let add_definition_to_map def_idx_and_def_and_linkable m =
     let (def_idx, def, def_linkable) = def_idx_and_def_and_linkable
     in
     match Map.lookup def.def_symname m with
@@ -123,12 +123,12 @@ let add_definition_to_map def_idx_and_def_and_linkable m =
     end
 
 val all_definitions_by_name : linkable_list -> Map.map string (list (natural * symbol_definition * linkable_item))
-let all_definitions_by_name linkables = 
-    (* Now that linkables are ELF memory images, we can make the 
+let all_definitions_by_name linkables =
+    (* Now that linkables are ELF memory images, we can make the
      * list of definitions much more easily. *)
     let list_of_deflists = List.mapi (fun (idx : nat) -> (fun (item : linkable_item) ->
         let img = image_of_linkable_item item
-        in 
+        in
         let (all_def_tags, all_def_ranges)
          = unzip (Multimap.lookupBy Memory_image_orderings.tagEquiv (SymbolDef(null_symbol_definition)) img.by_tag)
         in
@@ -140,12 +140,12 @@ let all_definitions_by_name linkables =
         [(naturalFromNat idx, def, def_linkable) | forall ((def, def_linkable) MEM all_defs) | true]
     )) linkables
     in
-    foldl (fun accum -> (fun deflist -> 
+    foldl (fun accum -> (fun deflist ->
         foldl (fun m -> (fun (def_idx, def, def_linkable) -> add_definition_to_map (def_idx, def, def_linkable) m)) accum deflist
     )) Map.empty list_of_deflists
- 
-type binding_oracle = 
-    linkable_list 
+
+type binding_oracle =
+    linkable_list
     -> Map.map string (list (natural * symbol_definition * linkable_item))
     -> (natural * symbol_reference * linkable_item)
     -> maybe (natural * symbol_definition * linkable_item)
@@ -154,8 +154,8 @@ val resolve_one_reference_default : forall 'abifeature. abi 'abifeature -> bindi
 let resolve_one_reference_default a linkables defmap ref_idx_and_ref_and_linkable =
     let (ref_idx, ref, ref_linkable) = ref_idx_and_ref_and_linkable
     in
-    (* Get the list of all definitions whose name matches. 
-     * Don't match empty names. 
+    (* Get the list of all definitions whose name matches.
+     * Don't match empty names.
      * How should we handle common symbols here?
      * A common symbol is a potential definition, so it goes in the def list.
      *)
@@ -165,9 +165,9 @@ let resolve_one_reference_default a linkables defmap ref_idx_and_ref_and_linkabl
         | Nothing -> []
     end
     in
-    (* Filter the list by eligibility rules. 
-     * Normally, 
-     * 
+    (* Filter the list by eligibility rules.
+     * Normally,
+     *
      * - any .o file can supply any other .o file on the command line
      * - any .a file supplies only files appearing to its left
      *      i.e. "it is searched once for definitions"
@@ -181,7 +181,7 @@ let resolve_one_reference_default a linkables defmap ref_idx_and_ref_and_linkabl
     in
     let ref_is_weak = (get_elf64_symbol_binding ref.ref_syment) = stb_weak
     in
-    let def_is_eligible = (fun (def_idx, def, def_linkable) -> 
+    let def_is_eligible = (fun (def_idx, def, def_linkable) ->
         let ref_is_unnamed = (ref.ref_symname = "")
         in
         let ref_is_to_defined_or_common_symbol = ((natural_of_elf64_half ref.ref_syment.elf64_st_shndx) <> stn_undef)
@@ -204,9 +204,9 @@ let resolve_one_reference_default a linkables defmap ref_idx_and_ref_and_linkabl
         let ref_is_leftmore = ref_idx <= def_idx
         in
         (* For simplicity we include the case of "same archive" in "in group with". *)
-        let ref_is_in_group_with_def = match def_in_group with 
+        let ref_is_in_group_with_def = match def_in_group with
               Nothing -> false
-            | Just def_gid -> 
+            | Just def_gid ->
                 match ref_coords with
                   InArchive(_, _, _, _) :: InGroup(gid, _) :: [_] -> gid = def_gid
                 | InGroup(gid, _) :: [_]                       -> gid = def_gid
@@ -215,10 +215,10 @@ let resolve_one_reference_default a linkables defmap ref_idx_and_ref_and_linkabl
             end
         in
         (* but maybe same archive? *)
-        (* DEBUGGING: print some stuff out if we care about this symbol. *)let _ = 
-            if ref_fname = "backtrace.o" && def.def_symname = "_Unwind_GetCFA" then 
+        (* DEBUGGING: print some stuff out if we care about this symbol. *)let _ =
+            if ref_fname = "backtrace.o" && def.def_symname = "_Unwind_GetCFA" then
                 (*Missing_pervasives.errln ("saw backtrace.o referencing _Unwind_GetCFA; coords are "
-                    ^ "def: " ^ (show def_coords) ^ ", ref: " ^ (show ref_coords) ^ "; ref_is_in_group_with_def: " 
+                    ^ "def: " ^ (show def_coords) ^ ", ref: " ^ (show ref_coords) ^ "; ref_is_in_group_with_def: "
                     ^ (show ref_is_in_group_with_def) ^ "; def_in_group: " ^ (show def_in_group))*)
               ()
             else ()
@@ -234,7 +234,7 @@ let resolve_one_reference_default a linkables defmap ref_idx_and_ref_and_linkabl
         end
         in
         if ref_is_to_defined_or_common_symbol then def_sym_is_ref_sym
-        else 
+        else
             if ref_is_unnamed then false
             else
                 if def_is_in_archive
@@ -247,21 +247,21 @@ let resolve_one_reference_default a linkables defmap ref_idx_and_ref_and_linkabl
                         || ref_and_def_are_in_same_archive
                         || ref_is_in_group_with_def
                     )
-                else 
+                else
                     true
     )
     in
     let eligible_defs = List.filter def_is_eligible defs_and_linkables_with_matching_name
     in
-    let (maybe_target_def_idx, maybe_target_def, maybe_target_def_linkable) = match eligible_defs with 
+    let (maybe_target_def_idx, maybe_target_def, maybe_target_def_linkable) = match eligible_defs with
         [] -> (Nothing, Nothing, Nothing)
         | [(def_idx, def, def_linkable)] -> (Just def_idx, Just def, Just def_linkable)
-        | (d_idx, d, d_l) :: more_pairs -> 
+        | (d_idx, d, d_l) :: more_pairs ->
             (* Break ties by
              * - putting defs in relocs (or --defsym or linker script, a.k.a. command line) ahead of defs in archives;
-             * - else whichever definition appeared first in the left-to-right order. 
+             * - else whichever definition appeared first in the left-to-right order.
              *)
-            let sorted = sortBy (fun (d_idx1, d1, (_, (_, _, (_, d_l1_coords)), _)) -> (fun (d_idx2, d2, (_, (_, _, (_, d_l2_coords)), _)) -> 
+            let sorted = sortBy (fun (d_idx1, d1, (_, (_, _, (_, d_l1_coords)), _)) -> (fun (d_idx2, d2, (_, (_, _, (_, d_l2_coords)), _)) ->
                 match (d_l1_coords, d_l2_coords) with
                       (InCommandLine(_) :: _, InCommandLine(_) :: _) -> d_idx1 < d_idx2
                     | (InCommandLine(_) :: _, _)                     -> (* command-line wins *) true
@@ -269,15 +269,15 @@ let resolve_one_reference_default a linkables defmap ref_idx_and_ref_and_linkabl
                     | (_, _) -> d_idx1 < d_idx2
                 end)) eligible_defs
             in
-            match sorted with 
+            match sorted with
                 (first_d_idx, first_d, first_d_l) :: _ -> (Just first_d_idx, Just first_d, Just first_d_l)
                 | _ -> failwith "impossible: sorted list is shorter than original"
             end
     end
-    in 
-    let refstr = "`" 
-                ^ ref.ref_symname ^ "' (" ^ 
-                (if (natural_of_elf64_half ref.ref_syment.elf64_st_shndx) = shn_undef then "UND" else "defined") ^ 
+    in
+    let refstr = "`"
+                ^ ref.ref_symname ^ "' (" ^
+                (if (natural_of_elf64_half ref.ref_syment.elf64_st_shndx) = shn_undef then "UND" else "defined") ^
                 " symbol at index " ^ (show ref.ref_sym_idx) ^ " in symtab "
                 ^ (show ref.ref_sym_scn) ^ " in " ^ ref_fname
                 ^ ")"
@@ -289,12 +289,12 @@ let resolve_one_reference_default a linkables defmap ref_idx_and_ref_and_linkabl
             (*let _ = Missing_pervasives.errln (" a definition in "^ (show (target_def_linkable)))
             in*)
             Just(target_def_idx, target_def, target_def_linkable)
-    |  (Nothing, Nothing, Nothing) -> 
+    |  (Nothing, Nothing, Nothing) ->
             (*let _ = Missing_pervasives.errln " no definition"
             in*)
-            if ref_is_weak (* || a.symbol_is_generated_by_linker ref.ref_symname *) then Nothing 
+            if ref_is_weak (* || a.symbol_is_generated_by_linker ref.ref_symname *) then Nothing
             else (* failwith ("undefined symbol: " ^ refstr) *) Nothing
-            (* FIXME: do a check, *after* the linker script has been interpreted, 
+            (* FIXME: do a check, *after* the linker script has been interpreted,
              * that all remaining undefined symbols are permitted by the ABI/policy. *)
     | _ -> failwith "impossible: non-matching maybes for target_def_idx and target_def"
     end
@@ -305,13 +305,13 @@ val resolve_all :
     -> binding_oracle
     -> list (natural * symbol_reference * linkable_item)
     -> list ((natural * symbol_reference * linkable_item) * maybe (natural * symbol_definition * linkable_item))
-let resolve_all linkables all_defs oracle refs = 
+let resolve_all linkables all_defs oracle refs =
     List.map (fun (ref_idx, ref, ref_linkable) -> ((ref_idx, ref, ref_linkable), (oracle linkables all_defs (ref_idx, ref, ref_linkable)))) refs
 
 (* To accumulate which inputs are needed, we work with a list of undefineds, starting with those
  * in the  forced-output objects. We then iteratively build a list of all needed symbol definitions,
  * pulling in the objects that contain them, until we reach a fixed point. *)
-val resolve_undefs_in_one_object : 
+val resolve_undefs_in_one_object :
     linkable_list
     -> Map.map string (list (natural * symbol_definition * linkable_item))                (* all definitions *)
     -> binding_oracle
@@ -325,18 +325,18 @@ let resolve_undefs_in_one_object linkables all_defs oracle idx =
     end
     in
     let img = image_of_linkable_item item
-    in 
+    in
     let (all_ref_tags, all_ref_ranges)
      = unzip (Multimap.lookupBy Memory_image_orderings.tagEquiv (SymbolRef(null_symbol_reference_and_reloc_site)) img.by_tag)
     in
-    (* By using SymbolRef, we are extracting and binding each relocation site individually. 
-     * since there might be more than one relocation site referencing the same symbol name, 
+    (* By using SymbolRef, we are extracting and binding each relocation site individually.
+     * since there might be more than one relocation site referencing the same symbol name,
      * in a given object.
-     * 
+     *
      * We are also binding SymbolRefs that have no relocation, which occur when there's
-     * an UND symbol which is not actually used by a relocation site, but is nevertheless 
+     * an UND symbol which is not actually used by a relocation site, but is nevertheless
      * in need of being resolved.
-     * 
+     *
      * We don't (for the moment) want to make different decisions for different reloc sites
      * in the same object referencing the same symbol. So we dedup from a list to a set.
      *)
@@ -347,14 +347,14 @@ let resolve_undefs_in_one_object linkables all_defs oracle idx =
     in
     let ref_triples = { (idx, ref, item) | forall (ref IN all_refs) | true }
     in
-    (*let _ = Missing_pervasives.errln ("object " ^ (show item) ^ " has " ^ 
-        (show (Set.size ref_triples)) ^ " reloc references (symname, sym_scn, sym_idx, st_shndx) (" ^ 
+    (*let _ = Missing_pervasives.errln ("object " ^ (show item) ^ " has " ^
+        (show (Set.size ref_triples)) ^ " reloc references (symname, sym_scn, sym_idx, st_shndx) (" ^
         (show (List.map (fun x -> ("\"" ^ x.ref_symname ^ "\"", x.ref_sym_scn, x.ref_sym_idx, natural_of_elf64_half x.ref_syment.elf64_st_shndx)) (Set_extra.toList all_refs))) ^ ")")
     in*)
     let und_ref_triples = { (idx, ref, ref_item) | forall ((idx, ref, ref_item) IN ref_triples) | natural_of_elf64_half ref.ref_syment.elf64_st_shndx = shn_undef }
     in
     (*let _ = Missing_pervasives.errln ("... of which " ^
-        (show (Set.size und_ref_triples)) ^ " are to undefined symbols: (symname, sym_scn, sym_idx, st_shndx) (" ^ 
+        (show (Set.size und_ref_triples)) ^ " are to undefined symbols: (symname, sym_scn, sym_idx, st_shndx) (" ^
         (show (List.map (fun (idx, x, _) -> ("\"" ^ x.ref_symname ^ "\"", x.ref_sym_scn, x.ref_sym_idx, natural_of_elf64_half x.ref_syment.elf64_st_shndx)) (Set_extra.toList und_ref_triples))) ^ ")")
     in*)
     resolve_all linkables all_defs oracle (Set_extra.toList ref_triples)
@@ -370,7 +370,7 @@ val accumulate_bindings_bf : forall 'abifeature.
 let rec accumulate_bindings_bf a linkables all_defs fully_bound to_bind bindings_accum =
     (* This is like foldl, except that each stage
      * can add stuff to the work list *)
-    match to_bind with 
+    match to_bind with
         [] -> bindings_accum (* termination *)
         | l_idx :: more_idx ->
             (* Get the new bindings for this object *)
@@ -382,14 +382,14 @@ let rec accumulate_bindings_bf a linkables all_defs fully_bound to_bind bindings
             in
             let new_fully_bound = Set.insert l_idx fully_bound
             in
-            (* Which of the new bindings are to objects 
+            (* Which of the new bindings are to objects
              * not yet fully bound or not yet in the to-bind list? *)
-            let new_bindings_def_idx = list_concat_map (fun (ref, maybe_def_and_idx_and_linkable) -> 
-                match maybe_def_and_idx_and_linkable with 
+            let new_bindings_def_idx = list_concat_map (fun (ref, maybe_def_and_idx_and_linkable) ->
+                match maybe_def_and_idx_and_linkable with
                     Just (def_idx, def, def_linkable) -> [def_idx]
                     | Nothing -> []
                 end
-            ) new_bindings 
+            ) new_bindings
             in
             let new_bindings_def_idx_set = Set.fromList new_bindings_def_idx
             in
@@ -400,10 +400,10 @@ let rec accumulate_bindings_bf a linkables all_defs fully_bound to_bind bindings
             let new_l_idx_list = Set_extra.toList new_l_idx
             in
             (*let _ = Missing_pervasives.errln (
-                if List.null new_l_idx_list 
+                if List.null new_l_idx_list
                 then
                     "Fully bound references in  " ^ (show (List.index linkables (natFromNatural l_idx)))
-                        ^ " using only already-included linkables (" 
+                        ^ " using only already-included linkables ("
                         ^ (show (List.map (fun i -> List.index linkables (natFromNatural i)) (Set_extra.toList included_linkables_idx)))
                 else
                     "Including additional linkables "
@@ -419,7 +419,7 @@ let rec accumulate_bindings_bf a linkables all_defs fully_bound to_bind bindings
                 (bindings_accum ++ new_bindings)
     end
 
-(* We need a generalised kind of depth-first search in which there are multiple start points. 
+(* We need a generalised kind of depth-first search in which there are multiple start points.
  * Also, we always work one object at a time, not one edge at a time; when we pull in an object,
  * we resolve *all* the references therein.
  *)
@@ -430,18 +430,18 @@ val accumulate_bindings_objectwise_df : forall 'abifeature.
 
     -> list ((natural * symbol_reference * linkable_item) * maybe (natural * symbol_definition * linkable_item))  (* bindings made so far *)
     -> set natural                                        (* inputs fully-bound so far -- these are "black" *)
-    -> list natural                                       (* inputs scheduled for binding -- these include 
+    -> list natural                                       (* inputs scheduled for binding -- these include
                                                              any "grey" (in-progress) nodes *and*
-                                                             any nodes that we have committed to exploring 
+                                                             any nodes that we have committed to exploring
                                                              (the "start nodes").
                                                              Because we're depth-first, we prepend our adjacent
-                                                             nodes to this list, making them grey, then we 
+                                                             nodes to this list, making them grey, then we
                                                              recurse by taking from the head. We must always
-                                                             filter out the prepended nodes from the existing list, 
+                                                             filter out the prepended nodes from the existing list,
                                                              to ensure we don't recurse infinitely. *)
     -> list ((natural * symbol_reference * linkable_item) * maybe (natural * symbol_definition * linkable_item))  (* all accumulated bindings bindings *)
 let rec accumulate_bindings_objectwise_df a linkables all_defs bindings_accum blacks greys =
-    match greys with 
+    match greys with
         [] -> bindings_accum (* termination *)
         | l_idx :: more_idx ->
             (* Get the new bindings for this object *)
@@ -450,19 +450,19 @@ let rec accumulate_bindings_objectwise_df a linkables all_defs bindings_accum bl
                 all_defs
                 (resolve_one_reference_default a)
                 l_idx
-            in 
+            in
             (* We pull in the whole object at a time ("objectwise"), so by definition,
              * we have created bindings for everything in this object; it's now black. *)
             let new_fully_bound = Set.insert l_idx blacks
             in
-            (* Which of the new bindings are to objects 
+            (* Which of the new bindings are to objects
              * not yet fully bound or not yet in the to-bind list? *)
-            let new_bindings_def_idx = list_concat_map (fun (ref, maybe_def_and_idx_and_linkable) -> 
-                match maybe_def_and_idx_and_linkable with 
+            let new_bindings_def_idx = list_concat_map (fun (ref, maybe_def_and_idx_and_linkable) ->
+                match maybe_def_and_idx_and_linkable with
                     Just (def_idx, def, def_linkable) -> [def_idx]
                     | Nothing -> []
                 end
-            ) new_bindings 
+            ) new_bindings
             in
             let new_bindings_def_idx_set = Set.fromList new_bindings_def_idx
             in
@@ -485,7 +485,7 @@ let rec accumulate_bindings_objectwise_df a linkables all_defs bindings_accum bl
             (* whether or not we've not uncovered any new white nodes, we tail-recurse  *)
             (*let _ = (if List.null new_l_idx_list then
                 Missing_pervasives.errln ("Fully bound references in  " ^ (show (List.index linkables (natFromNatural l_idx)))
-                    ^ " using only already-included linkables (" 
+                    ^ " using only already-included linkables ("
                     ^ (show (List.map (fun i -> List.index linkables (natFromNatural i)) (Set_extra.toList included_linkables_idx)))
                 ) else Missing_pervasives.errln ("Including additional linkables "
             ^ (show (List.mapMaybe (fun i -> List.index linkables (natFromNatural i)) new_l_idx_list))))
@@ -499,27 +499,27 @@ let rec accumulate_bindings_objectwise_df a linkables all_defs bindings_accum bl
                 (new_grey_list : list natural)
    end
 
-(* Rather than recursively expanding the link by searching for definitions of undefs, 
+(* Rather than recursively expanding the link by searching for definitions of undefs,
  * the GNU linker works by recursing/looping along the list of *linkables*, testing whether
- * any of the defs satisfies a currently-undef'd thing. On adding a new undef'd thing, 
- * we re-search only from the current archive, not from the beginning (i.e. the 
+ * any of the defs satisfies a currently-undef'd thing. On adding a new undef'd thing,
+ * we re-search only from the current archive, not from the beginning (i.e. the
  * "def_is_leftmore or def_in_same_archive" logic).
  *
  * Why is this not the same as depth-first? One example is if we pull in a new object
  * which happens to have two undefs: one satisfied by the *first* element in the current archive,
- * and one satisfied by the last. 
- * 
+ * and one satisfied by the last.
+ *
  * In the GNU algorithm, we'll pull in the first archive element immediately afterwards, because
  * we'll re-traverse the archive and find it's needed.
- * 
+ *
  * In the depth-first algorithm, it depends entirely on the ordering of the new bindings, i.e.
  * the symtab ordering of the two undefs. If the later-in-archive def was bound *first*, we'll
  * recurse down *that* object's dependencies first.
- * 
+ *
  * So if we sort the new grey list
  * so that bindings formed in order of *current archive def pos*,
  * will we get the same behaviour?
  * We can't really do this, because we have no "current archive".
- * 
+ *
  * Need to rewrite the algorithm to fold along the list of linkables.
  *)

--- a/src/memory_image.lem
+++ b/src/memory_image.lem
@@ -36,7 +36,7 @@ type byte_pattern_element = maybe byte
 type byte_pattern = list byte_pattern_element
 
 (* An element might have an address/offset, and it has some contents. *)
-type element = <| startpos : maybe natural 
+type element = <| startpos : maybe natural
                 ; length   : maybe natural
                 ; contents : byte_pattern
                 |>
@@ -49,9 +49,9 @@ type allocated_symbols_map = Map.map string (natural * natural) (* start, length
 
 type address_expr = natural -> allocated_symbols_map -> natural
                   ( pos     -> environment           -> result address )
-                  
+
    ... we model it as expressions in terms of CursorPosition. HMM.
-*) 
+*)
 
 type expr_operand = Var of string
                    | CursorPosition          (* only valid in certain expressions... HMM *)
@@ -61,13 +61,13 @@ type expr_operand = Var of string
 and
 expr_unary_operation = Neg of expr_operand
                            | BitwiseInverse of expr_operand
-and 
+and
 expr_binary_operation = Add of (expr_operand * expr_operand)
                            | Sub of (expr_operand * expr_operand)
                            | BitwiseAnd of (expr_operand * expr_operand)
                            | BitwiseOr of (expr_operand * expr_operand)
 
-type expr_binary_relation = 
+type expr_binary_relation =
     Lt
     | Lte
     | Gt
@@ -75,7 +75,7 @@ type expr_binary_relation =
     | Eq
     | Neq
 
-type expr = 
+type expr =
     False
     | True
     | Not of expr
@@ -100,12 +100,12 @@ type element_range = string * range
 
 (* An "element" of an ELF image, in the linking phase, is either a section,
  * the ELF header, the section header table or the program header table.
- * 
+ *
  * PROBLEM: We'd like to use section names as the identifiers
  * for those elements that are sections.
- * but we can't, because they are not guaranteed to be unique. 
- * 
- * SOLUTION: Names that are unique in the file are used as keys. 
+ * but we can't, because they are not guaranteed to be unique.
+ *
+ * SOLUTION: Names that are unique in the file are used as keys.
  * If not unique, the sections are treated as anonymous and given
  * gensym'd string ids (FIXME: implement this).
  *)
@@ -113,16 +113,16 @@ type element_range = string * range
 (* Currently, our elements have unique names, which are strings.
  * We *don't* want to encode any meaning onto these strings.
  * All meaning should be encoded into labelled ranges.
- * We want to be able to look up 
+ * We want to be able to look up
  *
  * - elements
  * - ranges within elements
- * 
+ *
  * ... by their *labels* -- or sometimes just *part* of their labels.
  *)
 
 (* ELF file features with which we can label ranges of the memory image. *)
-type elf_file_feature = 
+type elf_file_feature =
     ElfHeader of elf64_header
     | ElfSectionHeaderTable of elf64_section_header_table (* do we want to expand these? *)
     | ElfProgramHeaderTable of elf64_program_header_table
@@ -152,14 +152,14 @@ end
 type symbol_reference
  = <| ref_symname : string                  (* symbol name *)
     ; ref_syment : elf64_symbol_table_entry (* likely-undefined (referencing) symbol *)
-    ; ref_sym_scn : natural                 (* symtab section idx *) 
+    ; ref_sym_scn : natural                 (* symtab section idx *)
     ; ref_sym_idx : natural                 (* index into symbol table *)
     |>
 
 let symRefCompare x1 x2 =
         compare (x1.ref_symname, x1.ref_syment, x1.ref_sym_scn, x1.ref_sym_idx)
                 (x2.ref_symname, x2.ref_syment, x2.ref_sym_scn, x2.ref_sym_idx)
-                
+
 instance (Ord symbol_reference)
     let compare = symRefCompare
     let (<) = fun f1 -> (fun f2 -> (symRefCompare f1 f2 = LT))
@@ -169,7 +169,7 @@ instance (Ord symbol_reference)
 end
 
 type reloc_site = <|
-      ref_relent  : elf64_relocation_a 
+      ref_relent  : elf64_relocation_a
     ; ref_rel_scn : natural  (* the relocation section idx *)
     ; ref_rel_idx : natural  (* the index of the relocation rec *)
     ; ref_src_scn : natural  (* the section *from which* the reference logically comes *)
@@ -178,7 +178,7 @@ type reloc_site = <|
 let relocSiteCompare x1 x2 =
         compare (x1.ref_relent, x1.ref_rel_scn, x1.ref_rel_idx, x1.ref_src_scn)
                 (x2.ref_relent, x2.ref_rel_scn, x2.ref_rel_idx, x2.ref_src_scn)
-                
+
 instance (Ord reloc_site)
     let compare = relocSiteCompare
     let (<) = fun f1 -> (fun f2 -> (relocSiteCompare f1 f2 = LT))
@@ -186,7 +186,7 @@ instance (Ord reloc_site)
     let (>) = fun f1 -> (fun f2 -> (relocSiteCompare f1 f2 = GT))
     let (>=) = fun f1 -> (fun f2 -> Set.member (relocSiteCompare f1 f2) {GT; EQ})
 end
-    
+
 type reloc_decision = LeaveReloc
                     | ApplyReloc
                     | ChangeRelocTo of (natural * symbol_reference * reloc_site)
@@ -204,7 +204,7 @@ let relocDecisionCompare x1 x2 =
   end
 
 instance (Ord reloc_decision)
-  let compare = relocDecisionCompare 
+  let compare = relocDecisionCompare
   let (<) = fun f1 -> (fun f2 -> (relocDecisionCompare f1 f2 = LT))
   let (<=) = fun f1 -> (fun f2 -> Set.member (relocDecisionCompare f1 f2) {LT; EQ})
   let (>) = fun f1 -> (fun f2 -> (relocDecisionCompare f1 f2 = GT))
@@ -230,10 +230,10 @@ instance (Ord symbol_reference_and_reloc_site)
 end
 
 (* We can also annotate arbitrary ranges of bytes within an element
- * with arbitrary metadata. 
- * 
+ * with arbitrary metadata.
+ *
  * Ideally we want to data-abstract this a bit. But it's hard to do
- * so without baking in ELF-specific and/or (moreover) per-ABI concepts, 
+ * so without baking in ELF-specific and/or (moreover) per-ABI concepts,
  * like PLTs and GOTs. Ideally we would use something like polymorphic
  * variants here. For now, this has to be the union of all the concepts
  * that we find in the various ABIs we care about. To avoid ELFy things
@@ -250,20 +250,20 @@ type range_tag 'abifeature = (*  forall 'abifeature . *)
                | AbiFeature of 'abifeature
 
 type annotated_memory_image 'abifeature = <|
-      elements         : memory_image 
+      elements         : memory_image
     ; by_range         : set ((maybe element_range) * (range_tag 'abifeature))
     ; by_tag           : multimap (range_tag 'abifeature) (maybe element_range)
 |>
 
 val get_empty_memory_image : forall 'abifeature. unit -> annotated_memory_image 'abifeature
-let get_empty_memory_image = fun _ -> <| 
+let get_empty_memory_image = fun _ -> <|
       elements = Map.empty
     ; by_range = Set.empty
     ; by_tag   = Set.empty
 |>
 
 (* Basic ELFy and ABI-y things. *)
-(* "Special" sections are those that necessarily require special treatment by the 
+(* "Special" sections are those that necessarily require special treatment by the
  * linker. Examples include symbol tables and relocation tables. There are some
  * grey areas, such as .eh_frame, debug info, and string tables. For us, the rule
  * is that if we have special code to create them, i.e. that we don't rely on
@@ -278,9 +278,9 @@ let elf_section_is_special s f = s.elf64_section_type <> sht_progbits
                      && s.elf64_section_type <> sht_fini_array
                      && s.elf64_section_type <> sht_init_array
 
-(* This record collects things that ABIs may or must define. 
- * 
- * Since we want to put all ABIs in a list and select one at run time, 
+(* This record collects things that ABIs may or must define.
+ *
+ * Since we want to put all ABIs in a list and select one at run time,
  * we can't maintain a type-level distinction between ABIs; we have to
  * use elf_memory_image any_abi_feature. To avoid a reference cycle,
  * stay polymorphic in the ABI feature type until we define specific ABIs.
@@ -292,13 +292,13 @@ type null_abi_feature = unit
 (* The reloc calculation is complicated, so we split up the big function
  * type into smaller ones. *)
 
-(* Q. Do we want "existing", or is it a kind of addend? 
- * A. We do want it -- modelling both separately is necessary, 
+(* Q. Do we want "existing", or is it a kind of addend?
+ * A. We do want it -- modelling both separately is necessary,
  * because we model relocations bytewise, but some arches
  * do bitfield relocations (think ARM). *)
 type reloc_calculate_fn    = natural -> integer -> natural -> natural (* symaddr -> addend -> existing -> relocated *)
 
-type reloc_apply_fn 'abifeature = 
+type reloc_apply_fn 'abifeature =
                                 (* elf memory image: the context in which the relocation is being applied *)
                                 annotated_memory_image 'abifeature ->
                                (* the site address *)
@@ -309,31 +309,31 @@ type reloc_apply_fn 'abifeature =
                                  * However, sometimes the reference is itself a defined symbol.
                                  * Almost always, if so, *that* symbol *is* "the definition".
                                  * However, copy relocs are an exception.
-                                 * 
+                                 *
                                  * In the case of copy relocations being fixed up by the dynamic
                                  * linker, the dynamic linker must figure out which definition to
                                  * copy from. This can't be as simple as "the first definition in
                                  * link order", because *our* copy of that symbol is a definition
                                  * (typically in bss). It could be as simple as "the first *after us*
                                  * in link order". FIXME: find the glibc code that does this.
-                                 * 
+                                 *
                                  * Can we dig this stuff out of the memory image? If we pass the address
                                  * being relocated, we can find the tags. But I don't want to pass
                                  * the symbol address until the very end. It seems better to pass the symbol
                                  * name, since that's the key that the dynamic linker uses to look for
                                  * other definitions.
-                                 * 
+                                 *
                                  * Do we want to pass a whole symbol_reference? This has not only the
-                                 * symbol name but also syment, scn and idx. The syment is usually UND, 
+                                 * symbol name but also syment, scn and idx. The syment is usually UND,
                                  * but *could* be defined (and is for copy relocs). The scn and idx are
                                  * not relevant, but it seems cleaner to pass the whole thing anyway.
                                  *)
-                                symbol_reference_and_reloc_site -> 
+                                symbol_reference_and_reloc_site ->
                                 (* Should we pass a symbol_definition too? Implicitly, we pass part of it
                                  * by passing the symaddr argument (below). I'd prefer not to depend on
-                                 * others -- relocation calculations should look like "mostly address 
+                                 * others -- relocation calculations should look like "mostly address
                                  * arithmetic", i.e. only the weird ones do something else. *)
-                                 (* How wide, in bytes, is the relocated field? this may depend on img 
+                                 (* How wide, in bytes, is the relocated field? this may depend on img
                                  * and on the wider image (copy relocs), so it's returned *by* the reloc function. *)
                                 (natural (* width *) * reloc_calculate_fn)
 
@@ -366,8 +366,8 @@ type abi 'abifeature = (* forall 'abifeature. *)
     ; minpagesize        : natural
     ; commonpagesize     : natural
     ; symbol_is_generated_by_linker : string -> bool
-    (*; link_inputs_tap    : 
-    ; link_output_sections_tap   : 
+    (*; link_inputs_tap    :
+    ; link_output_sections_tap   :
     ; link_output_image_tap      : *)
     ; make_phdrs         : natural -> natural -> natural (* file type *) -> annotated_memory_image 'abifeature -> list elf64_interpreted_section -> list elf64_program_header_table_entry
     ; max_phnum          : natural
@@ -376,17 +376,17 @@ type abi 'abifeature = (* forall 'abifeature. *)
     ; pad_code           : natural -> list byte
     ; generate_support   : (* list (list reloc_site_resolution) ->  *)list (string * annotated_memory_image 'abifeature) -> annotated_memory_image 'abifeature
     ; concretise_support : annotated_memory_image 'abifeature -> annotated_memory_image 'abifeature
-    ; get_reloc_symaddr  : symbol_definition -> annotated_memory_image 'abifeature -> maybe reloc_site -> natural
+    ; get_reloc_symaddr  : symbol_definition -> annotated_memory_image 'abifeature -> list (maybe element_range * symbol_definition) -> maybe reloc_site -> natural
     |>
 
 val align_up_to : natural -> natural -> natural
-let align_up_to align addr = 
+let align_up_to align addr =
     let quot = addr / align
     in
     if quot * align = addr then addr else (quot + 1) * align
 
 val round_down_to : natural -> natural -> natural
-let round_down_to align addr = 
+let round_down_to align addr =
     let quot = addr / align
     in
     quot * align
@@ -396,8 +396,8 @@ let uint32_max = (2 ** 32) - 1
 
 val uint64_max : natural
 let uint64_max =
-    (* HACK around Lem's inability to parse 18446744073709551615: 
-     * the square of uint32_max is 
+    (* HACK around Lem's inability to parse 18446744073709551615:
+     * the square of uint32_max is
      *       (2**32 - 1) (2**32 - 1)
      * i.e.   2**64 - 2**32 - 2**32 + 1
      * So
@@ -413,19 +413,19 @@ let compl64 v =
     1 + (natural_lxor v uint64_max)
 
 val gcd : natural -> natural -> natural
-let rec gcd a b = 
+let rec gcd a b =
     if b = 0 then a else gcd b (a mod b)
 declare isabelle target_rep function gcd = `GCD.gcd`
 
 val lcm : natural -> natural -> natural
-let lcm a b = 
+let lcm a b =
     (* let _ = errln ("lcm of " ^ (show a) ^ " and " ^ (show b) ^ "?")
     in *)
     (a * b) / (gcd a b)
 declare isabelle target_rep function lcm = `GCD.lcm`
 
 val address_of_range : forall 'abifeature. element_range -> annotated_memory_image 'abifeature -> natural
-let address_of_range el_range img = 
+let address_of_range el_range img =
     let (el_name, (start, len)) = el_range
     in
     match Map.lookup el_name img.elements with
@@ -438,7 +438,7 @@ let address_of_range el_range img =
     end
 
 val range_contains : (natural * natural) -> (natural * natural) -> bool
-let range_contains (r1begin, r1len) (r2begin, r2len) = 
+let range_contains (r1begin, r1len) (r2begin, r2len) =
     (* r1 is at least as big as r2 *)
     r2begin >= r1begin && (r2begin + r2len) <= (r1begin + r1len)
 
@@ -446,9 +446,9 @@ val range_overlaps : (natural * natural) -> (natural * natural) -> bool
 let range_overlaps (r1begin, r1len) (r2begin, r2len) =
     (r1begin < (r2begin + r2len) && (r1begin + r1len) > r2begin)
      || (r2begin < (r1begin + r1len) && (r2begin + r2len) > r1begin)
-    
+
 val is_partition : list (natural * natural) -> list (natural * natural) -> bool
-let is_partition rs ranges = 
+let is_partition rs ranges =
     (* 1. each element of the first list falls entirely within some element
      * from the second list. *)
     let r_is_contained_by_some_range
@@ -461,7 +461,7 @@ let is_partition rs ranges =
 
 val     nat_range : natural -> natural -> list natural
 let rec nat_range base len =
-    match len with 
+    match len with
         0 -> []
     |   _ -> base :: (nat_range (base + 1) (len - 1))
     end
@@ -475,12 +475,12 @@ let rec expand_sorted_ranges sorted_ranges min_length accum =
             let pad_length = max 0 (min_length - (Missing_pervasives.length accum))
             in
             (* let _ = Missing_pervasives.errln (
-                "padding ranges cares list with " ^ (show pad_length) ^ 
-                " cares (accumulated " ^ (show (Missing_pervasives.length accum)) ^ 
+                "padding ranges cares list with " ^ (show pad_length) ^
+                " cares (accumulated " ^ (show (Missing_pervasives.length accum)) ^
                 ", min length " ^ (show min_length) ^ ")")
             in *)
             Missing_pervasives.replicate pad_length true)
-     |  (base, len) :: more -> 
+     |  (base, len) :: more ->
             (* pad the accum so that it reaches up to base *)
             let up_to_base = (Missing_pervasives.replicate (base - (Missing_pervasives.length accum)) true)
             in
@@ -494,65 +494,65 @@ let rec expand_unsorted_ranges unsorted_ranges min_length accum =
     expand_sorted_ranges (sortBy (fun (base1, len1) -> (fun (base2, len2) -> base1 < base2)) unsorted_ranges) min_length accum
 
 val make_byte_pattern_revacc : list (maybe byte) -> list byte -> list bool -> list (maybe byte)
-let rec make_byte_pattern_revacc revacc bytes cares = 
+let rec make_byte_pattern_revacc revacc bytes cares =
     match bytes with
           [] -> reverse revacc
-        | b :: bs -> match cares with 
+        | b :: bs -> match cares with
                 care :: more -> make_byte_pattern_revacc ((if not care then Nothing else Just b) :: revacc) bs more
               | _ -> failwith "make_byte_pattern: unequal length"
               end
     end
 
 val make_byte_pattern : list byte -> list bool -> list (maybe byte)
-let rec make_byte_pattern bytes cares = 
+let rec make_byte_pattern bytes cares =
     make_byte_pattern_revacc [] bytes cares
 
 val relax_byte_pattern_revacc : list (maybe byte) -> list (maybe byte) -> list bool -> list (maybe byte)
-let rec relax_byte_pattern_revacc revacc bytes cares = 
+let rec relax_byte_pattern_revacc revacc bytes cares =
     match bytes with
           [] -> reverse revacc
-        | b :: bs -> match cares with 
+        | b :: bs -> match cares with
                 care :: more -> relax_byte_pattern_revacc ((if not care then Nothing else b) :: revacc) bs more
               | _ -> failwith ("relax_byte_pattern: unequal length")
               end
     end
-    
+
 val relax_byte_pattern : list (maybe byte) -> list bool -> list (maybe byte)
-let rec relax_byte_pattern bytes cares = 
+let rec relax_byte_pattern bytes cares =
     relax_byte_pattern_revacc [] bytes cares
 
 type pad_fn = natural -> list byte
 
 val concretise_byte_pattern : list byte -> natural -> list (maybe byte) -> pad_fn -> list byte
-let rec concretise_byte_pattern rev_acc acc_pad bs pad = 
+let rec concretise_byte_pattern rev_acc acc_pad bs pad =
     match bs with
-        [] -> 
+        [] ->
             let padding_bytes = if acc_pad > 0 then pad acc_pad else []
             in List.reverse ((List.reverse padding_bytes) ++ rev_acc)
-        | Just(b) :: more -> 
+        | Just(b) :: more ->
             (* flush accumulated padding *)
             let padding_bytes = if acc_pad > 0 then pad acc_pad else []
             in
             concretise_byte_pattern (b :: ((List.reverse padding_bytes) ++ rev_acc)) 0 more pad
-        | Nothing :: more -> 
+        | Nothing :: more ->
             concretise_byte_pattern rev_acc (acc_pad+1) more pad
     end
 
 val byte_option_matches_byte : maybe byte -> byte -> bool
 let byte_option_matches_byte optb b =
-    match optb with 
-            Nothing -> true 
-        |   Just some -> some = b 
+    match optb with
+            Nothing -> true
+        |   Just some -> some = b
     end
 
 val byte_list_matches_pattern : list (maybe byte) -> list byte -> bool
-let rec byte_list_matches_pattern pattern bytes = 
-    match pattern with 
+let rec byte_list_matches_pattern pattern bytes =
+    match pattern with
         [] -> true
-        | optbyte :: more -> match bytes with 
+        | optbyte :: more -> match bytes with
                 [] -> false
-                | abyte :: morebytes -> 
-                    byte_option_matches_byte optbyte abyte 
+                | abyte :: morebytes ->
+                    byte_option_matches_byte optbyte abyte
                  && byte_list_matches_pattern more morebytes
             end
     end
@@ -572,27 +572,27 @@ let rec accum_pattern_possible_starts_in_one_byte_sequence pattern pattern_len s
         [] -> (* let _ = Missing_pervasives.errs ("terminating with hit (empty pattern)\n") in *)
             offset :: accum
         | bpe :: more_bpes -> (* nonempty, so check for nonempty seq *)
-            match seq with 
-                [] -> (*let _ = Missing_pervasives.errs ("terminating with miss (empty pattern)\n") 
+            match seq with
+                [] -> (*let _ = Missing_pervasives.errs ("terminating with miss (empty pattern)\n")
                     in *) accum (* ran out of bytes in the sequence, so no match *)
-                | byte :: more_bytes -> let matched_this_byte = 
+                | byte :: more_bytes -> let matched_this_byte =
                             byte_option_matches_byte bpe byte
                        in
-                       (* let _ = Missing_pervasives.errs ("Byte " ^ (show byte) ^ " matched " ^ (show byte_pattern) ^ "? " ^ (show matched_this_byte) ^ "; ") 
+                       (* let _ = Missing_pervasives.errs ("Byte " ^ (show byte) ^ " matched " ^ (show byte_pattern) ^ "? " ^ (show matched_this_byte) ^ "; ")
                        in *)
-                       let sequence_long_enough = (seq_len >= pattern_len) 
+                       let sequence_long_enough = (seq_len >= pattern_len)
                        in
-                       (* let _ = Missing_pervasives.errs ("enough bytes remaining (" ^ (show seq_len) ^ ") to match rest of pattern (" ^ (show pattern_len) ^ ")? " ^ (show sequence_long_enough) ^ "; ") 
+                       (* let _ = Missing_pervasives.errs ("enough bytes remaining (" ^ (show seq_len) ^ ") to match rest of pattern (" ^ (show pattern_len) ^ ")? " ^ (show sequence_long_enough) ^ "; ")
                        in *)
                        let matched_here = matched_this_byte && sequence_long_enough &&
                         byte_list_matches_pattern more_bpes more_bytes
                        in
-                       (* let _ = Missing_pervasives.errs ("matched pattern anchored here? " ^ (show matched_this_byte) ^ "\n") 
+                       (* let _ = Missing_pervasives.errs ("matched pattern anchored here? " ^ (show matched_this_byte) ^ "\n")
                        in *)
-                       accum_pattern_possible_starts_in_one_byte_sequence 
-                           pattern pattern_len 
-                           more_bytes (seq_len - 1) 
-                           (offset + 1) 
+                       accum_pattern_possible_starts_in_one_byte_sequence
+                           pattern pattern_len
+                           more_bytes (seq_len - 1)
+                           (offset + 1)
                            (if matched_here then offset :: accum else accum)
             end
     end
@@ -603,11 +603,11 @@ let by_range_from_by_tag = swap_pairs
 
 let by_tag_from_by_range = swap_pairs
 
-val filter_elements : forall 'abifeature. ((string * element) -> bool) -> 
+val filter_elements : forall 'abifeature. ((string * element) -> bool) ->
     annotated_memory_image 'abifeature -> annotated_memory_image 'abifeature
-let filter_elements pred img = 
-    let new_elements = Map.fromList [(n, r) | forall ((n, r) MEM (Set_extra.toList (toSet img.elements))) | 
-        let result = pred (n, r) in 
+let filter_elements pred img =
+    let new_elements = Map.fromList [(n, r) | forall ((n, r) MEM (Set_extra.toList (toSet img.elements))) |
+        let result = pred (n, r) in
         if not result then (*let _ = Missing_pervasives.outln ("Discarding element named " ^ n) in*) result else result]
     in
     let new_by_range =  Set.filter (fun (maybe_range, tag) -> match maybe_range with
@@ -624,7 +624,7 @@ let filter_elements pred img =
 
 val tag_image : forall 'abifeature. range_tag 'abifeature -> string -> natural -> natural -> annotated_memory_image 'abifeature
     ->  annotated_memory_image 'abifeature
-let tag_image t el_name el_offset tag_len img = 
+let tag_image t el_name el_offset tag_len img =
     let (k, v) = (Just (el_name, (el_offset, tag_len)), t)
     in
     let new_by_range = Set.insert (k, v) img.by_range
@@ -637,7 +637,7 @@ let tag_image t el_name el_offset tag_len img =
      |>
 
 val address_to_element_and_offset : forall 'abifeature. natural -> annotated_memory_image 'abifeature -> maybe (string * natural)
-let address_to_element_and_offset query_addr img = 
+let address_to_element_and_offset query_addr img =
     (* Find the element with the highest address <= addr.
      * What about zero-length elements?
      * Break ties on the bigger size. *)
@@ -651,15 +651,15 @@ let address_to_element_and_offset query_addr img =
         in*)
         match (maybe_current_max_le, el_rec.startpos) with
               (Nothing,                                    Nothing) -> Nothing
-            | (Nothing,                                    Just this_element_pos) -> if this_element_pos <= query_addr 
-                                                                                     then Just (this_element_pos, el_name, el_rec) 
+            | (Nothing,                                    Just this_element_pos) -> if this_element_pos <= query_addr
+                                                                                     then Just (this_element_pos, el_name, el_rec)
                                                                                      else Nothing
             | (Just (cur_max_le, cur_el_name, cur_el_rec), Nothing) ->               maybe_current_max_le
-            | (Just (cur_max_le, cur_el_name, cur_el_rec), Just this_element_pos) -> if this_element_pos <= query_addr 
-                                                                                        && (this_element_pos > cur_max_le 
+            | (Just (cur_max_le, cur_el_name, cur_el_rec), Just this_element_pos) -> if this_element_pos <= query_addr
+                                                                                        && (this_element_pos > cur_max_le
                                                                                          || (this_element_pos = cur_max_le
                                                                                              && (cur_el_rec.length = Just 0)))
-                                                                                        then Just (this_element_pos, el_name, el_rec) 
+                                                                                        then Just (this_element_pos, el_name, el_rec)
                                                                                         else maybe_current_max_le
         end
     )) Nothing (Map_extra.toList img.elements)
@@ -669,19 +669,19 @@ let address_to_element_and_offset query_addr img =
             (* final sanity check: is the length definite, and if so, does the
              * element span far enough? *)
             match el_rec.length with
-                Just l -> if el_def_startpos + l >= query_addr 
-                    then Just (el_name, query_addr - el_def_startpos) 
-                    else 
+                Just l -> if el_def_startpos + l >= query_addr
+                    then Just (el_name, query_addr - el_def_startpos)
+                    else
                         (*let _ = errln ("Discounting " ^ el_name ^ " because length is too short") in*) Nothing
                 | Nothing -> (*let _ = errln ("Gave up because element has unknown length") in*) Nothing
             end
-        | Nothing -> 
+        | Nothing ->
             (* no elements with a low enough assigned address, so nothing *)
             (*let _ = errln ("Found no elements with low enough address") in*) Nothing
     end
-    
+
 val element_and_offset_to_address : forall 'abifeature. (string * natural) -> annotated_memory_image 'abifeature -> maybe natural
-let element_and_offset_to_address (el_name, el_off) img = 
+let element_and_offset_to_address (el_name, el_off) img =
     match Map.lookup el_name img.elements with
         Just el -> match el.startpos with
                         Just addr -> Just (addr + el_off)
@@ -698,15 +698,15 @@ let null_symbol_reference = <|
 |>
 
 let null_elf_relocation_a =
-  <| elf64_ra_offset = elf64_addr_of_natural 0  
-   ; elf64_ra_info   = elf64_xword_of_natural 0 
+  <| elf64_ra_offset = elf64_addr_of_natural 0
+   ; elf64_ra_info   = elf64_xword_of_natural 0
    ; elf64_ra_addend = elf64_sxword_of_integer 0
    |>
 
 
 let null_symbol_reference_and_reloc_site = <|
       ref = null_symbol_reference
-    ; maybe_reloc = 
+    ; maybe_reloc =
         Just   <| ref_relent = null_elf_relocation_a
                 ; ref_rel_scn = 0
                 ; ref_rel_idx = 0
@@ -722,7 +722,7 @@ let null_symbol_definition = <|
     ; def_sym_idx = 0
     ; def_linkable_idx = 0
 |>
-    
+
 val pattern_possible_starts_in_one_byte_sequence : list (maybe byte) -> list byte -> natural -> list natural
 let pattern_possible_starts_in_one_byte_sequence pattern seq offset =
     (* let _ = Missing_pervasives.errs ("Looking for matches of " ^
@@ -740,7 +740,7 @@ let compute_virtual_address_adjustment max_page_size offset vaddr =
   (vaddr - offset) mod max_page_size
 
 val extract_natural_field : natural -> element -> natural -> natural
-let extract_natural_field width element offset = 
+let extract_natural_field width element offset =
     (* Read n bytes from the contents *)
     let maybe_bytes = take width (drop offset element.contents)
     in
@@ -752,13 +752,13 @@ let extract_natural_field width element offset =
     ) (0 : natural) bytes
 
 val natural_to_le_byte_list : natural -> list byte
-let rec natural_to_le_byte_list n = 
+let rec natural_to_le_byte_list n =
     (byte_of_natural (n mod 256)) :: (let d = n/256 in if d = 0 then [] else natural_to_le_byte_list (n / 256))
 
 val natural_to_le_byte_list_padded_to : natural -> natural -> list byte
-let rec natural_to_le_byte_list_padded_to width n = 
+let rec natural_to_le_byte_list_padded_to width n =
     let bytes = natural_to_le_byte_list n
-    in 
+    in
     bytes ++ (replicate (width - length bytes) (byte_of_natural 0))
 
 val n2i : natural -> integer
@@ -768,13 +768,13 @@ val i2n: integer -> natural
 let i2n = naturalFromInteger
 
 val i2n_signed : nat -> integer -> natural
-let i2n_signed width i = 
-    if i >= 0 then 
+let i2n_signed width i =
+    if i >= 0 then
         if i >= 2 ** (width-1) then failwith "overflow"
         else naturalFromInteger i
-    else 
+    else
         (* We manually encode the 2's complement of the negated value *)
-        let negated = naturalFromInteger (0 - i) in 
+        let negated = naturalFromInteger (0 - i) in
         let (xormask : natural) = (2 ** width - 1) in
         let compl = 1 + natural_lxor negated xormask
         in
@@ -782,15 +782,15 @@ let i2n_signed width i =
         in*) compl
 
 val to_le_signed_bytes : natural -> integer -> list byte
-let to_le_signed_bytes bytewidth i = 
+let to_le_signed_bytes bytewidth i =
     natural_to_le_byte_list_padded_to bytewidth (i2n_signed (natFromNatural (8*bytewidth)) i)
 
 val to_le_unsigned_bytes : natural -> integer -> list byte
-let to_le_unsigned_bytes bytewidth i = 
+let to_le_unsigned_bytes bytewidth i =
     natural_to_le_byte_list_padded_to bytewidth (naturalFromInteger i)
 
 val write_natural_field : natural -> natural -> element -> natural -> element
-let write_natural_field new_field_value width element offset = 
+let write_natural_field new_field_value width element offset =
     let pre_bytes = take offset element.contents
     in
     let post_bytes = drop (offset + width) element.contents

--- a/src/memory_image_orderings.lem
+++ b/src/memory_image_orderings.lem
@@ -30,7 +30,7 @@ open import Abi_classes
 open import Missing_pervasives
 
 val elfFileFeatureCompare : elf_file_feature -> elf_file_feature -> Basic_classes.ordering
-let elfFileFeatureCompare f1 f2 = 
+let elfFileFeatureCompare f1 f2 =
     (* order is: *)
     match (f1, f2) with
         (ElfHeader(x1), ElfHeader(x2)) -> (* equal tags, so ... *) compare x1 x2
@@ -56,7 +56,7 @@ let elfFileFeatureCompare f1 f2 =
     end
 
 val elfFileFeatureTagEquiv : elf_file_feature -> elf_file_feature -> bool
-let elfFileFeatureTagEquiv f1 f2 = 
+let elfFileFeatureTagEquiv f1 f2 =
     (* order is: *)
     match (f1, f2) with
         (ElfHeader(x1), ElfHeader(x2)) -> (* equal tags, so ... *) true
@@ -77,7 +77,7 @@ end
 
 val tagCompare : forall 'abifeature. Ord 'abifeature =>
     range_tag 'abifeature -> range_tag 'abifeature -> Basic_classes.ordering
-let tagCompare k1 k2 = 
+let tagCompare k1 k2 =
     match (k1, k2) with
         (ImageBase, ImageBase) -> EQ
         | (ImageBase, _) -> LT
@@ -117,7 +117,7 @@ instance forall 'abifeature. Ord 'abifeature => (Ord range_tag 'abifeature)
 end
 
 val tagEquiv : forall 'abifeature. AbiFeatureTagEquiv 'abifeature => range_tag 'abifeature -> range_tag 'abifeature -> bool
-let tagEquiv k1 k2 = 
+let tagEquiv k1 k2 =
     match (k1, k2) with
         (ImageBase, ImageBase) -> true
         | (EntryPoint, EntryPoint) -> true
@@ -132,17 +132,17 @@ let tagEquiv k1 k2 =
 
 
 val unique_tag_matching : forall 'abifeature. Ord 'abifeature, AbiFeatureTagEquiv 'abifeature => range_tag 'abifeature -> annotated_memory_image 'abifeature -> range_tag 'abifeature
-let unique_tag_matching tag img = 
+let unique_tag_matching tag img =
     match Multimap.lookupBy tagEquiv tag img.by_tag with
         [] -> failwith "no tag match found"
         | [(t, r)] -> t
-        | x -> failwith ("more than one tag match") (* (ranges: " ^ 
+        | x -> failwith ("more than one tag match") (* (ranges: " ^
             (show (List.map (fun (t, r) -> r) x))
             ^  ") when asserted unique")" *)
     end
-    
+
 val tagged_ranges_matching_tag : forall 'abifeature. Ord 'abifeature, AbiFeatureTagEquiv 'abifeature => range_tag 'abifeature -> annotated_memory_image 'abifeature -> list (range_tag 'abifeature * maybe element_range)
-let tagged_ranges_matching_tag tag img = 
+let tagged_ranges_matching_tag tag img =
     Multimap.lookupBy tagEquiv tag img.by_tag
 
 val element_range_compare : element_range -> element_range -> Basic_classes.ordering
@@ -153,7 +153,7 @@ val unique_tag_matching_at_range_exact : forall 'abifeature. Ord 'abifeature, Ab
     -> range_tag 'abifeature
     -> annotated_memory_image 'abifeature
     -> range_tag 'abifeature
-let unique_tag_matching_at_range_exact r tag img = 
+let unique_tag_matching_at_range_exact r tag img =
     (* 1. find tags a unique range labelled as ELF section header table. *)
     let (_, (allRangeMatches : list (range_tag 'abifeature))) = unzip (Multimap.lookupBy (=) r img.by_range)
     in
@@ -166,7 +166,7 @@ let unique_tag_matching_at_range_exact r tag img =
     end
 
 val symbol_def_ranges : forall 'abifeature. Ord 'abifeature, AbiFeatureTagEquiv 'abifeature => annotated_memory_image 'abifeature -> (list (range_tag 'abifeature) * list (maybe element_range))
-let symbol_def_ranges img = 
+let symbol_def_ranges img =
     (* find all element ranges labelled as ELF symbols *)
     let (tags, maybe_ranges) = unzip (
         tagged_ranges_matching_tag (SymbolDef(null_symbol_definition)) img
@@ -179,53 +179,52 @@ val name_of_symbol_def : symbol_definition -> string
 let name_of_symbol_def sym = sym.def_symname
 
 val defined_symbols_and_ranges : forall 'abifeature. Ord 'abifeature, AbiFeatureTagEquiv 'abifeature => annotated_memory_image 'abifeature -> list ((maybe element_range) * symbol_definition)
-let defined_symbols_and_ranges img = 
-    List.mapMaybe (fun (tag, maybeRange) -> 
+let defined_symbols_and_ranges img =
+    List.mapMaybe (fun (tag, maybeRange) ->
         match tag with
             SymbolDef(ent) -> Just (maybeRange, ent)
             | _ -> failwith "impossible: non-symbol def in list of symbol defs"
         end) (tagged_ranges_matching_tag (SymbolDef(null_symbol_definition)) img)
-    
+
 val make_ranges_definite : list (maybe element_range) -> list element_range
-let make_ranges_definite rs = 
+let make_ranges_definite rs =
     List.map (fun (maybeR : maybe element_range) -> match maybeR with
             Just r -> r
             | Nothing -> failwith "impossible: range not definite, but asserted to be"
         end) rs
 
-val find_defs_matching : forall 'abifeature. Ord 'abifeature, AbiFeatureTagEquiv 'abifeature => symbol_definition -> annotated_memory_image 'abifeature -> list ((maybe element_range) * symbol_definition)
-let find_defs_matching bound_def img = 
-    let (ranges_and_defs : list (maybe element_range * symbol_definition)) = defined_symbols_and_ranges img
-    in 
-    (*let _ = errln ("Searching (among " ^ (show (length ranges_and_defs)) ^ ") for the bound-to symbol `" ^ bound_def.def_symname 
-        ^ "', which came from linkable idx " ^ 
-        (show bound_def.def_linkable_idx) ^ ", section " ^ 
-        (show bound_def.def_syment.elf64_st_shndx) ^ 
-        ", symtab shndx " ^ (show bound_def.def_sym_scn) ^ 
+(* val find_defs_matching : forall 'abifeature. Ord 'abifeature, AbiFeatureTagEquiv 'abifeature => symbol_definition -> annotated_memory_image 'abifeature (* list (maybe element_range * symbol_definition) *) -> list ((maybe element_range) * symbol_definition) *)
+val find_defs_matching : symbol_definition -> list (maybe element_range * symbol_definition) -> list ((maybe element_range) * symbol_definition)
+let find_defs_matching bound_def ranges_and_defs =
+    (*let _ = errln ("Searching (among " ^ (show (length ranges_and_defs)) ^ ") for the bound-to symbol `" ^ bound_def.def_symname
+        ^ "', which came from linkable idx " ^
+        (show bound_def.def_linkable_idx) ^ ", section " ^
+        (show bound_def.def_syment.elf64_st_shndx) ^
+        ", symtab shndx " ^ (show bound_def.def_sym_scn) ^
         ", symind " ^ (show bound_def.def_sym_idx))
     in*)
-    List.mapMaybe (fun (maybe_some_range, some_def) -> 
+    List.mapMaybe (fun (maybe_some_range, some_def) ->
        (* let _ = errln ("Considering one: `" ^ some_def.def_symname ^ "'") in *)
        (* match maybe_some_range with
             Nothing -> failwith "symbol definition not over a definite range"
             | Just some_range -> *)
-                (* if some_def.def_symname = bound_def.def_symname 
+                (* if some_def.def_symname = bound_def.def_symname
                 && some_def.def_linkable_idx = bound_def.def_linkable_idx then
-                if some_def = bound_def 
+                if some_def = bound_def
                     then Just(maybe_some_range, some_def) else Nothing*)
                     (*let _ = errln ("Found one in the same linkable: syment is " ^
                         (show some_def.def_syment))
-                    in*) 
-                (*else*) if some_def = bound_def 
+                    in*)
+                (*else*) if some_def = bound_def
                             then (
                                 (*let _ = errln ("Found one: syment is " ^ (show some_def.def_syment))
                                 in*)
                                 Just(maybe_some_range, some_def)
                             )
                             else if some_def.def_symname = bound_def.def_symname then
-                                (*let _ = errln ("Warning: passing over name-matching def with section " ^ 
-                                    (show some_def.def_syment.elf64_st_shndx) ^ 
-                                    ", symtab shndx " ^ (show some_def.def_sym_scn) ^ 
+                                (*let _ = errln ("Warning: passing over name-matching def with section " ^
+                                    (show some_def.def_syment.elf64_st_shndx) ^
+                                    ", symtab shndx " ^ (show some_def.def_sym_scn) ^
                                     ", symind " ^ (show some_def.def_sym_idx) ^
                                     ", linkable idx " ^ (show some_def.def_linkable_idx))
                                 in*) Nothing
@@ -235,21 +234,22 @@ let find_defs_matching bound_def img =
 
 
 val defined_symbols : forall 'abifeature. Ord 'abifeature, AbiFeatureTagEquiv 'abifeature =>  annotated_memory_image 'abifeature -> list symbol_definition
-let defined_symbols img = 
+let defined_symbols img =
     let (all_symbol_tags, all_symbol_ranges) = symbol_def_ranges img in
-    List.mapMaybe (fun tag -> 
+    List.mapMaybe (fun tag ->
         match tag with
             SymbolDef(ent) -> Just ent
             | _ -> failwith "impossible: non-symbol def in list of symbol defs"
         end) all_symbol_tags
 
 
-let default_get_reloc_symaddr bound_def_in_input output_img maybe_reloc = 
-    match find_defs_matching bound_def_in_input output_img with
+val default_get_reloc_symaddr : forall 'abifeature. Ord 'abifeature, AbiFeatureTagEquiv 'abifeature => symbol_definition -> annotated_memory_image 'abifeature -> list (maybe element_range * symbol_definition) -> maybe reloc_site -> natural
+let default_get_reloc_symaddr bound_def_in_input output_img ranges_and_defs maybe_reloc =
+    match find_defs_matching bound_def_in_input ranges_and_defs with
         [] -> failwith ("internal error: bound-to symbol (name `" ^ bound_def_in_input.def_symname ^ "') not defined")
         | (maybe_range, d) :: more ->
-            let v = 
-                match maybe_range with 
+            let v =
+                match maybe_range with
                     Just(el_name, (start, len)) ->
                     match element_and_offset_to_address (el_name, start) output_img with
                         Just a -> a
@@ -262,7 +262,7 @@ let default_get_reloc_symaddr bound_def_in_input output_img maybe_reloc =
                             else failwith "no range for non-ABS symbol"
                 end
             in
-            match more with 
+            match more with
                 [] -> v
                 | _ -> (*let _ = errln ("FIXME: internal error: more than one def matching bound def `" ^
                     bound_def_in_input.def_symname ^ "'")


### PR DESCRIPTION
We used to do the following algorithm: for each processed symbol,
extract all symbols from the image, and search for a matching
symbol. Extracting symbols from the image once and for all is
possible since we're not producing any new symbol.

This allows a ~200% performance boost on a simple hello world program linked with glibc:
* Performance before: 40182.380 ms
* New performance: 17212.298 ms

Friendly diff: https://github.com/rems-project/linksem/pull/7/files?w=1