### PR TITLE
Fix ocamlbuild

### DIFF
--- a/src/lem.mk
+++ b/src/lem.mk
@@ -141,6 +141,8 @@ ldgram.y.hacked: ldgram.y
 	grep '\([:|;]\|[A-Za-z0-9_]\{2,\}\)' | \
 	tail -n+35 > "$@" || rm -f "$@"
 
+byte_sequence_impl.ml: lem_ocaml_sentinel $(OCAML_BYTE_SEQUENCE_IMPL)
+
 ALL_LEM_SRC := $(LEM_UTIL_SRC) $(LEM_ELF_SRC) $(LEM_ABI_SRC) $(LEM_LINK_SRC) $(OCAML_BYTE_SEQUENCE_IMPL) main_link.lem main_elf.lem scratch.lem copy_elf.lem
 $(patsubst %.lem,%.ml,$(ALL_LEM_SRC)): lem_ocaml_sentinel
 lem_ocaml_sentinel: $(ALL_LEM_SRC)


### PR DESCRIPTION
Commit https://github.com/rems-project/linksem/commit/e37bfcdcc0782242094a1bc58607cfa2a203a4b1 broke ocamlbuild builds. This commit tells the ocamlbuild target that `lem_ocaml_sentinel` will generate `byte_sequence_impl.ml`.