### PR TITLE
Add hol targets for natural_nat_shifts_

### DIFF
--- a/src/dwarf.lem
+++ b/src/dwarf.lem
@@ -699,9 +699,11 @@ let partialNaturalFromInteger (i:integer) : natural =
 
 val natural_nat_shift_left : natural -> nat -> natural
 declare ocaml    target_rep function natural_nat_shift_left = `Nat_big_num.shift_left`
+declare hol      target_rep function natural_nat_shift_left n m = (naturalPow 2 m) * n
 
 val natural_nat_shift_right : natural -> nat -> natural
 declare ocaml    target_rep function natural_nat_shift_right = `Nat_big_num.shift_right`
+declare hol      target_rep function natural_nat_shift_right n m = n / (naturalPow 2 m)
 
 
 


### PR DESCRIPTION
Addresses #20.

I am not sure whether this is the best approach: maybe a library function would be better instead of inline division and multiplication? As far as I know, there is no function already defined in HOL for natural numbers.